### PR TITLE
Document authenticationExtra field in MirrordKafkaClientConfig

### DIFF
--- a/using-mirrord/queue-splitting.md
+++ b/using-mirrord/queue-splitting.md
@@ -386,7 +386,10 @@ spec:
   properties: []
 ```
 
-Currently, only `MSK_IAM` is the only supported value for `spec.authenticationExtra.kind`.
+Currently, `MSK_IAM` is the only supported value for `spec.authenticationExtra.kind`.
+When this kind is specified, additional properties are automatically merged into the configuration:
+1. `sasl.mechanism=OAUTHBEARER`
+2. `security.protocol=SASL_SSL`
 
 > _**NOTE:**_ By default, the operator will only have access to secrets in its own namespace (`mirrord` by default).
 


### PR DESCRIPTION
Issue: https://linear.app/metalbear/issue/MBE-1329/document-authenticationextra-in-mirrordkafkaclientconfig