### PR TITLE
docs: remove stale Windows IDE plugin support note

### DIFF
--- a/docs/installing-mirrord/README.md
+++ b/docs/installing-mirrord/README.md
@@ -17,7 +17,6 @@ For your local machine, you may use any of:
 - MacOS (Intel, Apple Silicon)
 - Linux (x86_64)
 - Windows (x86_64), WSL (x86_64)
-  - IDE plugins support for native mirrord for Windows is currently not supported
 
 kubectl needs to be configured on the local machine.
 


### PR DESCRIPTION
## Summary
- Removes the outdated sub-bullet under Local Requirements that claimed IDE plugin support for native mirrord on Windows is not supported.

Native-Windows IDE plugins are now supported:
- **VS Code**: full support since `mirrord-vscode` 3.69.0 (Apr 2026) — "Implemented Windows support for extension".
- **JetBrains**: supported in `mirrord-intellij` 3.73.x for Rider Run + Debug, IntelliJ IDEA Build-System Run + Debug, and Gradle/Maven Run + Debug.

The "Using IDE extensions on Windows? See our WSL setup guide." line above is kept since WSL is still a valid alternative.

## Test plan
- [ ] Verify the rendered Installing mirrord page on GitBook no longer shows the stale bullet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)