### PR TITLE
docs: fix typos and stale CLI/UI references

### DIFF
--- a/docs/managing-mirrord/high-availability.md
+++ b/docs/managing-mirrord/high-availability.md
@@ -4,7 +4,7 @@ date: 2026-01-12T00:00:00.000Z
 lastmod: 2026-01-12T00:00:00.000Z
 draft: false
 images: []
-linktitle: High Availiability
+linktitle: High Availability
 menu: null
 docs: null
 teams: null

--- a/docs/reference/fileops.md
+++ b/docs/reference/fileops.md
@@ -89,7 +89,7 @@ Read from a file on the remote pod.
 Example:
 
 ```py
-fd = os.open("/tmp/test, os.O_RDWR | os.O_NONBLOCK | os.O_CLOEXEC)
+fd = os.open("/tmp/test", os.O_RDWR | os.O_NONBLOCK | os.O_CLOEXEC)
 read = os.read(fd, 1024)
 ```
 

--- a/docs/reference/traffic.md
+++ b/docs/reference/traffic.md
@@ -111,11 +111,11 @@ python3 user-service/service.py
 #### Window 2
 
 ```bash
-// Before running mirrord with `--tcp-steal`
+// Before running mirrord with `--steal`
 bigbear@metalbear:~/mirrord-demo$ curl http://192.168.49.2:32000/users
 [{"Last":"Bear","Name":"Metal"}]
 
-// After running with mirrord and `--tcp-steal` - local process responds
+// After running with mirrord and `--steal` - local process responds
  instead of the remote
 bigbear@metalbear:~/mirrord-demo$ curl http://192.168.49.2:32000/users
 []

--- a/docs/sharing-the-cluster/db-branch-management.md
+++ b/docs/sharing-the-cluster/db-branch-management.md
@@ -1,5 +1,5 @@
 ---
-title: "DB Branchimg Management"
+title: "DB Branching Management"
 description: "How to manage isolated mirrord DB branches for visibility and control"
 date: 2025-08-31T00:00:00+03:00
 lastmod: 2025-08-31T00:00:00+03:00

--- a/docs/sharing-the-cluster/db-branching-advanced-config.md
+++ b/docs/sharing-the-cluster/db-branching-advanced-config.md
@@ -16,22 +16,24 @@ These settings give additional flexibility in how mirrord handles database branc
 
 ```json
 {
-  "db_branches": [
-    {
-      "id": "users-mysql-db",            // Optional
-      "type": "mysql",                    // Available options [mysql|pg|mssql|mongodb]
-      "version": "8.0",
-      "name": "users-database-name",      // Optional
-      "ttl_secs": 60,                     // Optional, mutually exclusive with `ttl_mins`
-      "creation_timeout_secs": 20,        // Optional, Defaults to 60 if not specified
-      "connection": {
-        "url": "DB_CONNECTION_URL"
-      },
-      "copy": {
-        "mode": "empty"                   // Optional, Defaults to "empty" if not specified
+  "feature": {
+    "db_branches": [
+      {
+        "id": "users-mysql-db",            // Optional
+        "type": "mysql",                    // Available options [mysql|pg|mssql|mongodb]
+        "version": "8.0",
+        "name": "users-database-name",      // Optional
+        "ttl_secs": 60,                     // Optional, mutually exclusive with `ttl_mins`
+        "creation_timeout_secs": 20,        // Optional, Defaults to 60 if not specified
+        "connection": {
+          "url": "DB_CONNECTION_URL"
+        },
+        "copy": {
+          "mode": "empty"                   // Optional, Defaults to "empty" if not specified
+        }
       }
-    }
-  ]
+    ]
+  }
 }
 ```
 
@@ -367,14 +369,16 @@ Uses the standard AWS environment variables already present in the target pod.
 
 ```json
 {
-  "db_branches": [
-    {
-      "type": "pg",
-      "version": "16",
-      "connection": { "url": "DATABASE_URL" },
-      "iam_auth": { "type": "aws_rds" }
-    }
-  ]
+  "feature": {
+    "db_branches": [
+      {
+        "type": "pg",
+        "version": "16",
+        "connection": { "url": "DATABASE_URL" },
+        "iam_auth": { "type": "aws_rds" }
+      }
+    ]
+  }
 }
 ```
 
@@ -412,14 +416,16 @@ Uses the standard `GOOGLE_APPLICATION_CREDENTIALS` file path from target pod
 
 ```json
 {
-  "db_branches": [
-    {
-      "type": "pg",
-      "version": "17",
-      "connection": { "url": "DATABASE_URL" },
-      "iam_auth": { "type": "gcp_cloud_sql" }
-    }
-  ]
+  "feature": {
+    "db_branches": [
+      {
+        "type": "pg",
+        "version": "17",
+        "connection": { "url": "DATABASE_URL" },
+        "iam_auth": { "type": "gcp_cloud_sql" }
+      }
+    ]
+  }
 }
 ```
 

--- a/docs/using-mirrord/incoming-traffic/debug-from-browser.md
+++ b/docs/using-mirrord/incoming-traffic/debug-from-browser.md
@@ -40,7 +40,7 @@ It binds to localhost, prints a URL, and opens it in your default browser:
 
 ```
   mirrord session monitor
-    Web UI: http://[::1]:59281?token=...
+    Web UI: http://127.0.0.1:59281?token=...
 ```
 
 The Web UI page does an automatic handshake with the extension (over Chrome's `externally_connectable` mechanism) and hands it the daemon's address and a one-shot token. You should see this confirmation:

--- a/docs/using-mirrord/local-ui.md
+++ b/docs/using-mirrord/local-ui.md
@@ -36,7 +36,7 @@ The CLI starts an HTTP + WebSocket server bound to localhost, generates a one-sh
 
 ```
   mirrord session monitor
-    Web UI: http://[::1]:59281?token=...
+    Web UI: http://127.0.0.1:59281?token=...
 ```
 
 The token is required on every API request, so there's no need to expose the dashboard beyond your machine. Each invocation generates a fresh token.

--- a/docs/using-mirrord/multiple-concurrent-sessions.md
+++ b/docs/using-mirrord/multiple-concurrent-sessions.md
@@ -1,8 +1,8 @@
 ---
 title: "mirrord up (multiple concurrent sessions)"
 description: "How to use mirrord up"
-date: 2026-04-014T16:25:00+04:00
-lastmod: 2026-04-014T16:25:00+04:00 
+date: 2026-04-24T16:25:00+04:00
+lastmod: 2026-04-24T16:25:00+04:00
 draft: false
 menu:
   docs:
@@ -123,7 +123,7 @@ Allows specifying a different config file, e.g. `mirrord up -f mirrord-up-custom
 Specifies the network mode for all defined services, overriding `default_mode`. Available options:
 - `split`:
 
-Defaults to `split`. For more details, see `services.*.defualt_mode`.
+Defaults to `split`. For more details, see `services.*.default_mode`.
 
 ### `--key`
 Allows specifying a custom session key. When not supplied, the OS username is used.


### PR DESCRIPTION
## Summary
Mechanical cleanup pass from a doc audit. Each fix is backed by a concrete source-of-truth:

**Typos / broken examples**
- `sharing-the-cluster/db-branch-management.md`: page title was "DB Branchimg Management".
- `managing-mirrord/high-availability.md`: `linktitle` was "High Availiability".
- `using-mirrord/multiple-concurrent-sessions.md`: frontmatter `date`/`lastmod` were `2026-04-014T...` (invalid month-day); fixed to `2026-04-24`. Also `defualt_mode` -> `default_mode`.
- `reference/fileops.md`: Python example was missing a closing quote (`os.open("/tmp/test, ...`).

**Stale CLI flag**
- `reference/traffic.md`: replaces `--tcp-steal` with `--steal`. The CLI arg is defined as `#[arg(long = "steal")]` in `mirrord/cli/src/config.rs`, and `--tcp-steal` was renamed elsewhere in docs PR #127 — this file was missed.

**Stale session UI binding**
- `using-mirrord/local-ui.md` and `using-mirrord/incoming-traffic/debug-from-browser.md`: change `http://[::1]:59281` to `http://127.0.0.1:59281`. mirrord 3.207.0 changelog: "The session UI binds on `127.0.0.1` instead of `[::1]` so the page origin matches what the extension's `externally_connectable` manifest entry accepts."

**Config nesting consistency**
- `sharing-the-cluster/db-branching-advanced-config.md`: three top-level JSON examples had `db_branches` at the root. Wraps them under `feature: { ... }` so they're consistent with `db-branching.md` after #170 ("Nest db_branches under feature in DB branching examples").

## Test plan
- [ ] Render preview shows the updated examples correctly.
- [ ] Spot-check that `--steal` is the only flag mentioned in `reference/traffic.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)