### PR TITLE
docs: document ReplicaSet/Service targets, fs modes, native-Windows IDE support

### DIFF
--- a/docs/installing-mirrord/intellij.md
+++ b/docs/installing-mirrord/intellij.md
@@ -9,6 +9,10 @@ If you develop your application in one of the JetBrains' IDEs (e.g PyCharm, Inte
 2. Enable mirrord using the toolbar button (next to "mirrord" popup menu) ![Select Active Config action](intellij/images/enabler.png)
 3. Run or debug your application as you usually do
 
+{% hint style="info" %}
+The plugin runs natively on Windows since mirrord-intellij `3.73.0` for these scenarios: Rider Run + Debug, IntelliJ IDEA Build-System Run + Debug, and IDEA Gradle/Maven Build-System Run + Debug. Other run configurations on Windows still require [WSL](wsl.md#using-mirrord-in-intellij).
+{% endhint %}
+
 When you start a debugging session with mirrord enabled, you'll be prompted with a target selection dialog. This dialog will allow you to select the target in your Kubernetes cluster that you want to impersonate.
 
 > **Note**: For some projects, the plugin might not be able to present the target selection dialog.

--- a/docs/installing-mirrord/vscode.md
+++ b/docs/installing-mirrord/vscode.md
@@ -11,6 +11,10 @@ If you develop your application in Visual Studio Code, you can debug it with mir
 The mirrord extension is also available for all VS Code forks like Cursor, Windsurf, Antigravity, PearAI, and Trae.
 {% endhint %}
 
+{% hint style="info" %}
+The extension runs natively on Windows since mirrord-vscode `3.69.0`. WSL is still supported as an alternative — see [WSL](wsl.md#using-mirrord-in-vs-code).
+{% endhint %}
+
 2. Enable mirrord using the "mirrord" button on the bottom toolbar 
 
 ![mirrord button](vscode/images/enabler.png)

--- a/docs/reference/fileops.md
+++ b/docs/reference/fileops.md
@@ -16,8 +16,18 @@ tags: ["open source", "team", "enterprise"]
 ## Overview
 
 mirrord will relay file access (except for some exceptions ([Unix](https://github.com/metalbear-co/mirrord/blob/main/mirrord/layer-lib/src/file/unix/read_local_by_default.rs) | [Windows](https://github.com/metalbear-co/mirrord/blob/main/mirrord/layer-lib/src/file/windows/read_local_by_default.rs))) to the
-target pod by default. (this functionality can be disabled using `--fs-mode local` flag on the command line or by
-setting `mode` in the configuration file in the IDE plugin.)
+target pod by default. This functionality is controlled by the `feature.fs.mode` configuration option (or the `--fs-mode` CLI flag).
+
+### Modes
+
+| Mode | Behavior |
+|------|----------|
+| `local` | All file operations happen on the local filesystem. mirrord doesn't touch fs syscalls. |
+| `localwithoverrides` | Mostly local, but mirrord still applies its built-in overrides for a small set of paths (the default exception lists linked above). |
+| `read` *(default)* | Reads go to the remote pod, writes go to the local filesystem. |
+| `write` | Both reads and writes go to the remote pod. |
+
+User overrides and mirrord's default overrides apply on top of the selected mode — for instance, `read` mode will still resolve a handful of paths locally (DNS files, the user's home directory, etc.).
 
 For example, the following python script calls the built-in `open` function which translate to something like
 `openat(AT_FDCWD, "/tmp/test", O_RDWR|O_CLOEXEC)` at a lower level:

--- a/docs/reference/targets.md
+++ b/docs/reference/targets.md
@@ -35,8 +35,12 @@ mirrord for Teams adds support for the following workloads:
 * Jobs
 * CronJobs
 * StatefulSets
+* ReplicaSets
+* Services
 
 In mirrord for Teams, mirrord will always target all pods when a workload with multiple pods is used as the remote target.
+
+When targeting a Service, mirrord resolves the Service to its backing pods via the Service's selector. Jobs and CronJobs require [`copy_target`](../using-mirrord/copy-target.md) to be enabled.
 
 Both in mirrord OSS and mirrord for Teams, if you don't name any specific container to be targeted, mirrord will pick the first container from the pod spec. Some containers, like service mesh proxies, will be automatically ignored.
 


### PR DESCRIPTION
## Summary
Four shipped features that aren't yet in the docs. All backed by code or CHANGELOG.

### `reference/targets.md` — add ReplicaSet and Service to the Teams target list
Both are defined as variants of `Target` in `mirrord/config/src/target.rs` (operator-required). CHANGELOG entries:
- "Added Kubernetes ReplicaSet as a new target type (requires mirrord Operator)."
- "Kubernetes Service as a new type of mirrord target (requires mirrord operator)."

Also explicitly notes the long-standing `copy_target` requirement for Jobs/CronJobs that already lives in the rustdoc on the enum.

### `reference/fileops.md` — add a Modes table
The page never enumerated the four fs modes. Defined in `mirrord/config/src/feature/fs/mode.rs`: `local`, `localwithoverrides`, `read` (default), `write`.

### `installing-mirrord/vscode.md` — native-Windows callout
mirrord-vscode 3.69.0 (2026-04-10): "Implemented Windows support for extension." The page previously didn't mention native Windows at all and only linked WSL.

### `installing-mirrord/intellij.md` — native-Windows callout with scope
mirrord-intellij 3.73.0 (2026-04-24): "Added support for Windows for the respective IDEs and scenarios: Rider Run + Debug, IDEA IntelliJ Build-System Run + Debug and IDEA Gradle/Maven Build-System Run + Debug." Other run configurations on Windows still need WSL — keeping that path discoverable.

## Test plan
- [ ] Render preview shows the new content rendered correctly (table in fileops.md, hint blocks in vscode/intellij).
- [ ] Verify the WSL anchor `#using-mirrord-in-intellij` resolves on the rendered wsl.md page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)