### PR TITLE
Add prerequisites section to Preview Environments docs

### DIFF
--- a/docs/use-cases/preview-environments.md
+++ b/docs/use-cases/preview-environments.md
@@ -21,6 +21,12 @@ This enables realistic validation workflows without cloning an entire environmen
 Preview Environments are available to users on the **Enterprise** pricing plan.
 {% endhint %}
 
+## Prerequisites
+
+- **Operator 3.142.0 or later** — the feature was introduced in this version.
+- **CLI 3.189.0 or later** — the `mirrord preview` subcommand was introduced in this version.
+- **Helm flag** — `operator.previewEnv` must be set to `true` in your Helm values (defaults to `false`).
+
 # What Is a Preview Environment?
 
 Today, mirrord sessions are tightly coupled to a developer's local process. When that process stops, the testing environment disappears.


### PR DESCRIPTION
## Summary

- Adds a **Prerequisites** section to the Preview Environments page listing the minimum operator version (3.142.0), CLI version (3.189.0), and the `operator.previewEnv` Helm flag requirement.

Came up while onboarding a client — they hit the "feature not supported" error because the Helm flag wasn't enabled and there was no mention of prerequisites in the docs.

## Test plan

- [ ] Verify the prerequisites section renders correctly on the docs site
- [ ] Confirm operator and CLI version numbers are accurate


Made with [Cursor](https://cursor.com)