### PR TITLE
docs: fix canonical email + broken WSL anchor in intellij.md

### DIFF
--- a/docs/faq/general.md
+++ b/docs/faq/general.md
@@ -62,7 +62,7 @@ Yes! You can use the `mirrord container` command to run a local container in the
 
 ## What if I can't create containers with the capabilities mirrord requires in my cluster?
 
-mirrord works by creating an agent on a privileged pod in the remote cluster that accesses another pod's namespaces (read more about it [here](https://metalbear.com/blog/getting-started-with-ephemeral-containers/)). If you can't give your end users permissions to create pods with the capabilities mirrord needs, we suggest trying out [mirrord for Teams](../managing-mirrord/operator.md). It adds a Kubernetes operator that acts as a control plane for mirrord clients, and lets them work with mirrord without creating pods themselves. If mirrord for Teams doesn't work for you either, [let us know](mailto:hello@metalbear.com) and we'll try to figure a solution that matches your security policies.
+mirrord works by creating an agent on a privileged pod in the remote cluster that accesses another pod's namespaces (read more about it [here](https://metalbear.com/blog/getting-started-with-ephemeral-containers/)). If you can't give your end users permissions to create pods with the capabilities mirrord needs, we suggest trying out [mirrord for Teams](../managing-mirrord/operator.md). It adds a Kubernetes operator that acts as a control plane for mirrord clients, and lets them work with mirrord without creating pods themselves. If mirrord for Teams doesn't work for you either, [let us know](mailto:hi@metalbear.com) and we'll try to figure a solution that matches your security policies.
 
 ## What kinds of Kubernetes objects can I use as a remote target?
 

--- a/docs/installing-mirrord/intellij.md
+++ b/docs/installing-mirrord/intellij.md
@@ -81,4 +81,4 @@ You can also pin the binary version in the plugin settings (`Settings -> Tools -
 
 ## WSL
 
-The guide on how to use the plugin with remote development on WSL can be found [here](wsl.md#root-project-intellij).
+The guide on how to use the plugin with remote development on WSL can be found [here](wsl.md#using-mirrord-in-intellij).


### PR DESCRIPTION
## Summary
Two small fixes bundled together.

### `faq/general.md` — canonical contact email
Line 65 still pointed at `hello@metalbear.com`. `hi@metalbear.com` is the canonical contact address (and matches `managing-mirrord/security.md` and `troubleshooting/common-issues.md`).

### `installing-mirrord/intellij.md` — broken WSL anchor
Line 80 linked to `wsl.md#root-project-intellij`. That anchor doesn't exist in `wsl.md`. The actual section heading is `### Using mirrord in IntelliJ`, which Hugo renders as `#using-mirrord-in-intellij`.

Folds in the content originally proposed in #187.

🤖 Generated with [Claude Code](https://claude.com/claude-code)