### PR TITLE
docs: fix broken WSL anchor in intellij.md

### DIFF
--- a/docs/installing-mirrord/intellij.md
+++ b/docs/installing-mirrord/intellij.md
@@ -81,4 +81,4 @@ You can also pin the binary version in the plugin settings (`Settings -> Tools -
 
 ## WSL
 
-The guide on how to use the plugin with remote development on WSL can be found [here](wsl.md#root-project-intellij).
+The guide on how to use the plugin with remote development on WSL can be found [here](wsl.md#using-mirrord-in-intellij).


### PR DESCRIPTION
## Summary
Line 80 linked to `wsl.md#root-project-intellij`. That anchor doesn't exist in `wsl.md`. The actual section heading is `### Using mirrord in IntelliJ`, which Hugo renders as `#using-mirrord-in-intellij`.

## Test plan
- [ ] Anchor `wsl.md#using-mirrord-in-intellij` resolves on the rendered page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)