### PR TITLE
docs: Reference deep-dive + Using thinning

### DIFF
--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -16,26 +16,48 @@ tags:
 description: mirrord's architecture
 ---
 
-mirrord runs the user's local process unchanged, but rewires its syscalls so file, network, DNS, and environment operations happen in the context of a remote Kubernetes target.
+mirrord is composed of the following components:
+
+* `mirrord-agent` - Rust binary that is packaged as a container image. mirrord-agent runs in the cloud and acts as a proxy for the local process.
+* `mirrord-layer` - Rust dynamic library for Unix systems (so/dylib) that loads to the local process, hooks its filesystem, network APIs and relays them to the agent.
+* `mirrord-layer-win` - Rust dynamic library for Windows (dll) that loads to the local process, hooks its filesystem, network APIs and relays them to the agent.
+* `mirrord-intproxy` - Local subprocess that owns the connection to the agent and routes messages to/from the layer(s).
+* `mirrord-cli` - Rust binary that wraps the behavior of the respective mirrord layer in a user friendly CLI.
+* `mirrord-operator` (Teams) - Cluster-wide controller that fronts the agent for mirrord for Teams users.
+* `VS Code extension` - Exposes the same functionality as mirrord-cli within the VS Code IDE.
+* `JetBrains plugin` - Exposes the same functionality as mirrord-cli within JetBrains IDEs. 
 
 ![mirrord - Architecture](architecture/architecture.svg)
 
-## Components
+## mirrord-agent
 
-- **`mirrord-cli`**: user-facing binary. Resolves the target, launches intproxy, injects the layer via `LD_PRELOAD`/`DYLD_INSERT_LIBRARIES`, and `exec`s the user command. Also fronts the VS Code and JetBrains extensions.
-- **`mirrord-layer` / `mirrord-layer-win`**: a dynamic library loaded into the user process. Hooks libc functions for file, socket, DNS, and exec operations. Each intercepted call either bypasses to the original implementation (for paths that should stay local) or becomes a protocol request to intproxy.
-- **`mirrord-intproxy`**: a local subprocess that owns the connection to the agent and routes messages to/from the layer. Lets multiple processes in the same session (forks, execs) share one agent connection.
-- **`mirrord-agent`**: a Rust binary packaged as a container image, scheduled on the same node as the target. Joins the target's network and mount namespaces and does the actual remote work: traffic mirroring/stealing, outgoing connections, DNS resolution, file ops, env reads.
-- **`mirrord-operator`** (Teams): cluster-wide controller that fronts the agent for Teams users. Allows multiple users to attach to the same workload, enforces policies, and provides sharing primitives ([queue splitting](../sharing-the-cluster/queue-splitting.md), [DB branching](../sharing-the-cluster/db-branching.md), [profiles](../sharing-the-cluster/profiles.md)).
+mirrord-agent is a Kubernetes job that runs in the same Linux namespace as the pod being impersonated in the cluster. This lets the mirrored-agent sniff the network traffic and gain access to the filesystem of the impersonated pod. It then relays file operations from the local process to the impersonated pod and incoming traffic from the impersonated pod to the local process. Outgoing traffic is intercepted at the local process and emitted by the agent as if originating from the impersonated pod. The connection between the agent and the impersonated pod is terminated if the agent pod hits a timeout.
 
-In OSS, intproxy talks directly to the agent via `kubectl port-forward`. With the operator, intproxy talks to the operator, which proxies to the agent.
+mirrord-agent does **not** run as a privileged container in the cluster, but it does need a small set of Linux capabilities to join the target pod's namespaces. See [Security](../managing-mirrord/security.md) for the full list, the RBAC posture, and how to drop individual capabilities via [`agent.disabled_capabilities`](https://metalbear.com/mirrord/docs/config#agent.disabled_capabilities).
 
-The agent is not privileged (it does not run as root in the cluster sense), but does need a small set of Linux capabilities to join the target pod's namespaces. See [Security](../managing-mirrord/security.md) for the full list, the RBAC posture, and how to drop individual capabilities via [`agent.disabled_capabilities`](https://metalbear.com/mirrord/docs/config#agent.disabled_capabilities).
+## mirrord-layer
 
-## Related
+mirrord-layer is a `.dylib` file for OSX systems and `.so` file on Linux distributions. mirrord-layer is loaded through `LD_PRELOAD/DYLD_INSERT_LIBRARIES` environment variable with the local process, which lets mirrord-layer selectively override libc functions. The overridden functions are then responsible for maintaining coordination between the process and incoming/outgoing requests for network traffic/file access. mirrord-layer sends and receives events from the agent using port-forwarding.
 
-- [Targets](targets.md): what kinds of resources can be impersonated
-- [Network Traffic](traffic.md): incoming, outgoing, and DNS
-- [File Operations](fileops.md): how fs syscalls are intercepted and routed
-- [Environment Variables](env.md): how the env fetch works
-- [Sharing the cluster](../sharing-the-cluster/overview.md): what the operator unlocks
+## mirrord-layer-win
+mirrord-layer-win is a `.dll` file. It is dynamically loaded into the local process, started in a frozen state, and execution begins after the library has been fully initialized. It selectively overrides functions at the lowest level we can get to in user-mode, often right before your operation is dispatched to the kernel through a syscall. The overriden functions are then responsible for maintaining coordination between the process and incoming/outgoing requests for network traffic/file access.
+
+## mirrord-intproxy
+
+mirrord-intproxy is a small local process spawned by the CLI. It owns the connection to the agent (over `kubectl port-forward` in OSS, or through the operator in Teams) and routes messages to and from the layer(s). When the user app forks or execs another mirrord-aware process, the new layer connects to the existing intproxy instead of opening a fresh agent connection, so one session can span many processes.
+
+## mirrord-operator
+
+mirrord-operator is a cluster-wide controller that fronts the agent for mirrord for Teams users. It resolves targets, authorizes them against the policy layer, allows multiple users to attach to the same workload, and provides session-sharing primitives like [queue splitting](../sharing-the-cluster/queue-splitting.md), [DB branching](../sharing-the-cluster/db-branching.md), and [profiles](../sharing-the-cluster/profiles.md). In OSS, intproxy talks directly to the agent; with the operator, intproxy talks to the operator, which proxies to the agent.
+
+## mirrord-cli
+
+mirrord-cli is a user friendly interface over the essential functionality provided by the respective mirrord layer. When you run mirrord-cli, it runs the process provided as an argument with the respective mirrord layer loaded into it.
+
+## VS Code Extension
+
+mirrord’s VS Code extension provides mirrord’s functionality within VS Code’s UI. When you debug a process with mirrord enabled in VS Code, it prompts you for a pod to impersonate, then runs the debugged process with the respective mirrord layer loaded into it.
+
+## JetBrains Plugin
+
+mirrord’s JetBrains plugin provides mirrord’s functionality within JetBrains IDEs. When you debug a process with mirrord enabled, it prompts you for a pod to impersonate, then runs the debugged process with the respective mirrord layer loaded into it.

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -26,13 +26,19 @@ mirrord runs the user's local process unchanged, but rewires its syscalls so fil
 ┌────────────────────────────────────────────────────────────────────────┐
 │ LOCAL MACHINE                                                          │
 │                                                                        │
-│  ┌──────────────────────┐         ┌──────────────────────┐             │
-│  │ User application     │         │ mirrord CLI          │             │
-│  │ ┌──────────────────┐ │         │ - resolves target    │             │
-│  │ │  mirrord-layer   │◄┼─────────┤ - starts intproxy    │             │
-│  │ │  (LD_PRELOAD /   │ │         │ - sets env + injects │             │
-│  │ │   DYLD_INSERT)   │ │         │   layer              │             │
-│  │ └────────┬─────────┘ │         └──────────────────────┘             │
+│  ┌──────────────────────┐                                              │
+│  │ mirrord CLI          │  - resolves target                           │
+│  │                      │  - starts intproxy                           │
+│  │                      │  - sets LD_PRELOAD / DYLD_INSERT_LIBRARIES   │
+│  │                      │  - execs the user command                    │
+│  └──────────┬───────────┘                                              │
+│             │ exec()                                                   │
+│             ▼                                                          │
+│  ┌──────────────────────┐                                              │
+│  │ User application     │  OS dynamic linker sees LD_PRELOAD /         │
+│  │ ┌──────────────────┐ │  DYLD_INSERT_LIBRARIES and loads             │
+│  │ │  mirrord-layer   │ │  libmirrord_layer.so/.dylib into the         │
+│  │ └────────┬─────────┘ │  process before main() runs.                 │
 │  └──────────┼───────────┘                                              │
 │             │ local protocol (TCP / Unix)                              │
 │             │                                                          │
@@ -60,11 +66,15 @@ mirrord runs the user's local process unchanged, but rewires its syscalls so fil
 
 ### `mirrord-cli`
 
-The user-facing binary. Resolves the target via the Kubernetes API, decides whether to connect through the operator or directly (`operator: false`), launches the intproxy, sets up environment variables (`LD_PRELOAD`/`DYLD_INSERT_LIBRARIES` for the layer, intproxy address), and execs the user's command. Also fronts the IDE extensions — VS Code and JetBrains plugins call into the same CLI.
+The user-facing binary. Resolves the target via the Kubernetes API, decides whether to connect through the operator or directly (`operator: false`), launches the intproxy, sets up environment variables (`LD_PRELOAD`/`DYLD_INSERT_LIBRARIES` pointing at the layer library, intproxy address, config-derived feature flags), and `exec`s the user's command. Also fronts the IDE extensions — VS Code and JetBrains plugins call into the same CLI.
+
+The CLI does **not** load the layer itself. Loading happens in the next step, driven by the OS dynamic linker.
 
 ### `mirrord-layer` / `mirrord-layer-win`
 
-A dynamic library loaded into the user process. On Linux it's a `.so` injected via `LD_PRELOAD`; on macOS a `.dylib` via `DYLD_INSERT_LIBRARIES`; on Windows a `.dll` loaded into a frozen process before execution begins.
+A dynamic library, not a process. On Linux and macOS, when the CLI sets `LD_PRELOAD` / `DYLD_INSERT_LIBRARIES` and `exec`s the user command, the OS dynamic linker sees the env var and loads the layer library (`libmirrord_layer.so` / `.dylib`) into the new process's address space before its entry point runs. The layer's constructor then installs hooks and connects to intproxy.
+
+On Windows the same role is played by `mirrord-layer-win`: a `.dll` loaded into the user process via a separate injection mechanism (the process is started in a frozen state so the library is fully initialized before execution begins).
 
 The layer hooks libc functions (or the Windows-equivalent low-level APIs) for file, socket, DNS, and exec operations. Each intercepted call is either bypassed to the original implementation (for paths that should stay local) or converted into a protocol request and sent to the intproxy.
 
@@ -126,7 +136,7 @@ For [`mirrord container`](../using-mirrord/local-container.md) and other scenari
    - **OSS path**: CLI creates the agent pod (a `Job`), waits for it to be ready, sets up a port-forward.
    - **Teams path**: CLI authenticates with the operator, opens a session, and gets back a connection.
 3. **intproxy start**: CLI spawns intproxy as a local subprocess. intproxy connects to the agent (port-forward or operator tunnel).
-4. **Layer injection**: CLI sets `LD_PRELOAD`/`DYLD_INSERT_LIBRARIES`, intproxy address, and config-derived env vars, then execs the user command. The layer initializes immediately on process start.
+4. **Layer load**: CLI sets `LD_PRELOAD`/`DYLD_INSERT_LIBRARIES` (pointing at the layer library), the intproxy address, and config-derived env vars, then `exec`s the user command. The OS dynamic linker loads the layer into the new process before its entry point runs; the layer's constructor installs hooks and opens a session with intproxy.
 5. **Initial fetch**: The layer fetches remote env vars from the agent (synchronous, before the user code runs) and sets them on the process.
 6. **Runtime operations**: Each hooked syscall becomes a `ClientMessage`. intproxy routes it to the agent, the agent executes, and the response (`DaemonMessage`) flows back. The layer translates the response into what the syscall's caller expects.
 7. **Teardown**: When the user process exits, the layer disconnects, intproxy shuts down, and (OSS) the agent pod is deleted, or (Teams) the operator closes the session.

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -16,84 +16,23 @@ tags:
 description: mirrord's architecture
 ---
 
-mirrord runs the user's local process unchanged, but rewires its syscalls so file, network, DNS, and environment operations happen in the context of a remote Kubernetes target. This page describes the components involved, how they connect, and what happens during a session.
+mirrord runs the user's local process unchanged, but rewires its syscalls so file, network, DNS, and environment operations happen in the context of a remote Kubernetes target.
 
 ![mirrord - Architecture](architecture/architecture.svg)
 
 ## Components
 
-```
-┌────────────────────────────────────────────────────────────────────────┐
-│ LOCAL MACHINE                                                          │
-│                                                                        │
-│  ┌──────────────────────┐                                              │
-│  │ mirrord CLI          │  - resolves target                           │
-│  │                      │  - starts intproxy                           │
-│  │                      │  - sets LD_PRELOAD / DYLD_INSERT_LIBRARIES   │
-│  │                      │  - execs the user command                    │
-│  └──────────┬───────────┘                                              │
-│             │ exec()                                                   │
-│             ▼                                                          │
-│  ┌──────────────────────┐                                              │
-│  │ User application     │  OS dynamic linker sees LD_PRELOAD /         │
-│  │ ┌──────────────────┐ │  DYLD_INSERT_LIBRARIES and loads             │
-│  │ │  mirrord-layer   │ │  libmirrord_layer.so/.dylib into the         │
-│  │ └────────┬─────────┘ │  process before main() runs.                 │
-│  └──────────┼───────────┘                                              │
-│             │ local protocol (TCP / Unix)                              │
-│             │                                                          │
-│  ┌──────────▼───────────┐                                              │
-│  │  mirrord-intproxy    │  Routes messages between layer(s) and agent  │
-│  └──────────┬───────────┘                                              │
-└─────────────┼──────────────────────────────────────────────────────────┘
-              │ mirrord-protocol  (over port-forward
-              │                    or operator-managed tunnel)
-┌─────────────┼──────────────────────────────────────────────────────────┐
-│ CLUSTER     │                                                          │
-│  ┌──────────▼───────────┐                                              │
-│  │    mirrord-agent     │  Joins target's namespaces, performs         │
-│  │  (target node, in    │  remote fs / network / DNS / env             │
-│  │   target's netns +   │  operations on the target's behalf           │
-│  │   mountns)           │                                              │
-│  └──────────────────────┘                                              │
-│                                                                        │
-│  ┌──────────────────────┐                                              │
-│  │  mirrord-operator    │  (Teams only) Manages targets, sessions,     │
-│  │   (cluster-wide)     │  policies, queue-splitting, db-branching     │
-│  └──────────────────────┘                                              │
-└────────────────────────────────────────────────────────────────────────┘
-```
+- **`mirrord-cli`**: user-facing binary. Resolves the target, launches intproxy, injects the layer via `LD_PRELOAD`/`DYLD_INSERT_LIBRARIES`, and `exec`s the user command. Also fronts the VS Code and JetBrains extensions.
+- **`mirrord-layer` / `mirrord-layer-win`**: a dynamic library loaded into the user process. Hooks libc functions for file, socket, DNS, and exec operations. Each intercepted call either bypasses to the original implementation (for paths that should stay local) or becomes a protocol request to intproxy.
+- **`mirrord-intproxy`**: a local subprocess that owns the connection to the agent and routes messages to/from the layer. Lets multiple processes in the same session (forks, execs) share one agent connection.
+- **`mirrord-agent`**: a Rust binary packaged as a container image, scheduled on the same node as the target. Joins the target's network and mount namespaces and does the actual remote work: traffic mirroring/stealing, outgoing connections, DNS resolution, file ops, env reads.
+- **`mirrord-operator`** (Teams): cluster-wide controller that fronts the agent for Teams users. Allows multiple users to attach to the same workload, enforces policies, and provides sharing primitives ([queue splitting](../sharing-the-cluster/queue-splitting.md), [DB branching](../sharing-the-cluster/db-branching.md), [profiles](../sharing-the-cluster/profiles.md)).
 
-### `mirrord-cli`
+In OSS, intproxy talks directly to the agent via `kubectl port-forward`. With the operator, intproxy talks to the operator, which proxies to the agent.
 
-The user-facing binary. Resolves the target via the Kubernetes API, decides whether to connect through the operator or directly (`operator: false`), launches the intproxy, sets up environment variables (`LD_PRELOAD`/`DYLD_INSERT_LIBRARIES` pointing at the layer library, intproxy address, config-derived feature flags), and `exec`s the user's command. Also fronts the IDE extensions: VS Code and JetBrains plugins call into the same CLI.
+## Agent capabilities
 
-The CLI does **not** load the layer itself. Loading happens in the next step, driven by the OS dynamic linker.
-
-### `mirrord-layer` / `mirrord-layer-win`
-
-A dynamic library, not a process. On Linux and macOS, when the CLI sets `LD_PRELOAD` / `DYLD_INSERT_LIBRARIES` and `exec`s the user command, the OS dynamic linker sees the env var and loads the layer library (`libmirrord_layer.so` / `.dylib`) into the new process's address space before its entry point runs. The layer's constructor then installs hooks and connects to intproxy.
-
-On Windows the same role is played by `mirrord-layer-win`: a `.dll` loaded into the user process via a separate injection mechanism (the process is started in a frozen state so the library is fully initialized before execution begins).
-
-The layer hooks libc functions (or the Windows-equivalent low-level APIs) for file, socket, DNS, and exec operations. Each intercepted call is either bypassed to the original implementation (for paths that should stay local) or converted into a protocol request and sent to the intproxy.
-
-### `mirrord-intproxy`
-
-A small local process that sits between the layer(s) and the agent. It exists because:
-
-- The agent connection (port-forward or operator tunnel) is expensive to open per-process. With intproxy, when a target binary forks or execs another mirrord-aware process, the new layer connects to the existing intproxy instead of opening a new agent connection.
-- The layer runs inside the user process where it can't do things like long-running async I/O safely. intproxy owns the agent connection and handles the bookkeeping (request/response matching, reconnects, file-handle state, port subscriptions).
-
-intproxy is structured as a set of feature-specific proxies (files, incoming, outgoing, DNS, env) that each manage their own state and route messages to/from the agent.
-
-### `mirrord-agent`
-
-A Rust binary packaged as a container image, run as a Kubernetes pod scheduled on the same node as the target. It joins the target pod's network namespace and mount namespace (`CAP_SYS_ADMIN`) and reads its PID namespace (`CAP_SYS_PTRACE`), giving the agent the same view of networking, filesystem, and process state the target container has.
-
-The agent does the actual work: installing iptables redirections for steal subscriptions, opening outgoing sockets, resolving DNS via the pod's resolver, reading `/proc/<target-pid>/environ`, and accessing the container's filesystem via `/proc/<target-pid>/root`.
-
-Required Linux capabilities:
+The agent is not privileged (it does not run as root in the cluster sense), but it does need Linux capabilities to impersonate the target pod:
 
 | Capability | Why |
 |---|---|
@@ -103,52 +42,12 @@ Required Linux capabilities:
 
 You can drop any subset via [`agent.disabled_capabilities`](https://metalbear.com/mirrord/docs/config#agent.disabled_capabilities), which will disable the corresponding features.
 
-The agent is **not** privileged (it does not run as root in the cluster sense) and only operates on the targets the user is authorized to access (via Kubernetes RBAC or, for Teams, the operator's policy layer).
-
-### `mirrord-protocol`
-
-Defines the messages exchanged between layer ↔ intproxy ↔ agent: `ClientMessage` (sent by the client side toward the agent) and `DaemonMessage` (sent by the agent back). Serialized with bincode over a TCP connection.
-
-Between the layer and the intproxy there's a separate, lighter local protocol (`mirrord-intproxy-protocol`) with `LayerToProxyMessage` / `ProxyToLayerMessage`.
-
-Backward compatibility is mandatory: the agent, layer, and intproxy ship and upgrade independently, so older clients must keep working against newer agents and vice versa within the supported version window.
-
-### `mirrord-operator` (Teams)
-
-A cluster-wide controller that fronts the agent for Teams users. The operator:
-
-- Resolves targets and authorizes them against the policy layer
-- Allows multiple users to attach to the same workload (and coordinates concurrent steal locks via `on_concurrent_steal`)
-- Provides session sharing primitives for [queue splitting](../sharing-the-cluster/queue-splitting.md), [DB branching](../sharing-the-cluster/db-branching.md), and [profiles](../sharing-the-cluster/profiles.md)
-- Exposes agents over a single tunnel rather than per-user port-forwards
-- Records sessions for audit and visibility ([admin dashboard](../managing-mirrord/admin-dashboard.md))
-
-In OSS, intproxy talks directly to the agent via `kubectl port-forward`. With the operator, intproxy talks to the operator, which proxies to the agent.
-
-### `mirrord-external-proxy` (container mode)
-
-For [`mirrord container`](../using-mirrord/local-container.md) and other scenarios where the user process runs inside a separate container/VM, an additional process (the external proxy) sits between the container boundary and the intproxy. The intproxy runs in the same network namespace as the user process; the external proxy stays on the host and forwards messages between intproxy and agent. Most users never interact with it directly.
-
-## Lifecycle of a `mirrord exec` session
-
-1. **CLI invocation**: `mirrord exec -t <target> -- <command>`. CLI loads config, validates it, and resolves the target via the Kubernetes API.
-2. **Agent setup**:
-   - **OSS path**: CLI creates the agent pod (a `Job`), waits for it to be ready, sets up a port-forward.
-   - **Teams path**: CLI authenticates with the operator, opens a session, and gets back a connection.
-3. **intproxy start**: CLI spawns intproxy as a local subprocess with the CLI's normal environment (no `LD_PRELOAD`). intproxy is a regular process; nothing is injected into it. It binds a local socket (TCP or Unix) and connects out to the agent (port-forward or operator tunnel).
-4. **Layer load**: CLI `exec`s the user command, passing a **per-exec** augmented environment: `LD_PRELOAD`/`DYLD_INSERT_LIBRARIES` (pointing at the layer library), `MIRRORD_INTPROXY_ADDR` (the address from step 3), and config-derived feature flags. These vars never live on the CLI's own process environment, so they don't leak into intproxy or any other sibling process. The OS dynamic linker reads `LD_PRELOAD` from the new process's environment and loads the layer into the user process before its entry point runs; the layer's constructor installs hooks and connects to intproxy at `MIRRORD_INTPROXY_ADDR`. (Any subprocess the user app later spawns inherits `LD_PRELOAD` from the user app's environment, so it also gets the layer loaded — and connects to the same intproxy.)
-5. **Initial fetch**: The layer fetches remote env vars from the agent (synchronous, before the user code runs) and sets them on the process.
-6. **Runtime operations**: Each hooked syscall becomes a `ClientMessage`. intproxy routes it to the agent, the agent executes, and the response (`DaemonMessage`) flows back. The layer translates the response into what the syscall's caller expects.
-7. **Teardown**: When the user process exits, the layer disconnects, intproxy shuts down, and (OSS) the agent pod is deleted, or (Teams) the operator closes the session.
-
-## IDE extensions
-
-The [VS Code extension](../installing-mirrord/vscode.md) and [JetBrains plugin](../installing-mirrord/intellij.md) wrap the same CLI mechanism. They surface a target-picker dialog (when no target is in the config or env), set up the same `LD_PRELOAD`/`DYLD_INSERT_LIBRARIES` injection, and start the debugged process under that environment. From mirrord's perspective there's no difference between a CLI exec and an IDE-launched debug session. The IDE is just a different way of invoking the CLI machinery.
+The agent only operates on the targets the user is authorized to access (via Kubernetes RBAC or, for Teams, the operator's policy layer).
 
 ## Related
 
 - [Targets](targets.md): what kinds of resources can be impersonated
-- [Network Traffic](traffic.md): how incoming, outgoing, and DNS routing work
+- [Network Traffic](traffic.md): incoming, outgoing, and DNS
 - [File Operations](fileops.md): how fs syscalls are intercepted and routed
 - [Environment Variables](env.md): how the env fetch works
 - [Sharing the cluster](../sharing-the-cluster/overview.md): what the operator unlocks

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -16,44 +16,129 @@ tags:
 description: mirrord's architecture
 ---
 
-mirrord is composed of the following components:
-
-* `mirrord-agent` - Rust binary that is packaged as a container image. mirrord-agent runs in the cloud and acts as a proxy for the local process.
-* `mirrord-layer` - Rust dynamic library for Unix systems (so/dylib) that loads to the local process, hooks its filesystem, network APIs and relays them to the agent.
-* `mirrord-layer-win` - Rust dynamic library for Windows (dll) that loads to the local process, hooks its filesystem, network APIs and relays them to the agent.
-* `mirrord-cli` - Rust binary that wraps the behavior of the respective mirrord layer in a user friendly CLI.
-* `VS Code extension` - Exposes the same functionality as mirrord-cli within the VS Code IDE.
-* `JetBrains plugin` - Exposes the same functionality as mirrord-cli within JetBrains IDEs. 
+mirrord runs the user's local process unchanged, but rewires its syscalls so file, network, DNS, and environment operations happen in the context of a remote Kubernetes target. This page describes the components involved, how they connect, and what happens during a session.
 
 ![mirrord - Architecture](architecture/architecture.svg)
 
-## mirrord-agent
+## Components
 
-mirrord-agent is a Kubernetes job that runs in the same Linux namespace as the pod being impersonated in the cluster. This lets the mirrored-agent sniff the network traffic and gain access to the filesystem of the impersonated pod. It then relays file operations from the local process to the impersonated pod and incoming traffic from the impersonated pod to the local process. Outgoing traffic is intercepted at the local process and emitted by the agent as if originating from the impersonated pod. The connection between the agent and the impersonated pod is terminated if the agent pod hits a timeout.
+```
+┌────────────────────────────────────────────────────────────────────────┐
+│ LOCAL MACHINE                                                          │
+│                                                                        │
+│  ┌──────────────────────┐         ┌──────────────────────┐             │
+│  │ User application     │         │ mirrord CLI          │             │
+│  │ ┌──────────────────┐ │         │ - resolves target    │             │
+│  │ │  mirrord-layer   │◄┼─────────┤ - starts intproxy    │             │
+│  │ │  (LD_PRELOAD /   │ │         │ - sets env + injects │             │
+│  │ │   DYLD_INSERT)   │ │         │   layer              │             │
+│  │ └────────┬─────────┘ │         └──────────────────────┘             │
+│  └──────────┼───────────┘                                              │
+│             │ local protocol (TCP / Unix)                              │
+│             │                                                          │
+│  ┌──────────▼───────────┐                                              │
+│  │  mirrord-intproxy    │  Routes messages between layer(s) and agent  │
+│  └──────────┬───────────┘                                              │
+└─────────────┼──────────────────────────────────────────────────────────┘
+              │ mirrord-protocol  (over port-forward
+              │                    or operator-managed tunnel)
+┌─────────────┼──────────────────────────────────────────────────────────┐
+│ CLUSTER     │                                                          │
+│  ┌──────────▼───────────┐                                              │
+│  │    mirrord-agent     │  Joins target's namespaces, performs         │
+│  │  (target node, in    │  remote fs / network / DNS / env             │
+│  │   target's netns +   │  operations on the target's behalf           │
+│  │   mountns)           │                                              │
+│  └──────────────────────┘                                              │
+│                                                                        │
+│  ┌──────────────────────┐                                              │
+│  │  mirrord-operator    │  (Teams only) Manages targets, sessions,     │
+│  │   (cluster-wide)     │  policies, queue-splitting, db-branching     │
+│  └──────────────────────┘                                              │
+└────────────────────────────────────────────────────────────────────────┘
+```
 
-mirrord-agent does **not** run as a privileged container in the cluster. However, it requires some [Linux capabilities](https://man7.org/linux/man-pages/man7/capabilities.7.html) to be able to impersonate the targeted pod. These capabilities are:
+### `mirrord-cli`
 
-* `CAP_NET_ADMIN` and `CAP_NET_RAW` - required for modifying routing tables
-* `CAP_SYS_PTRACE` - required for reading target pod environment
-* `CAP_SYS_ADMIN` - required for joining target pod network namespace
+The user-facing binary. Resolves the target via the Kubernetes API, decides whether to connect through the operator or directly (`operator: false`), launches the intproxy, sets up environment variables (`LD_PRELOAD`/`DYLD_INSERT_LIBRARIES` for the layer, intproxy address), and execs the user's command. Also fronts the IDE extensions — VS Code and JetBrains plugins call into the same CLI.
 
-However, you can disable any subset of those in the configuration using [agent.disabled\_capabilities](https://metalbear.com/mirrord/docs/config#agent.disabled_capabilities) option. This will possibly limit mirrord functionalities or even make it unusable in some setups.
+### `mirrord-layer` / `mirrord-layer-win`
 
-## mirrord-layer
+A dynamic library loaded into the user process. On Linux it's a `.so` injected via `LD_PRELOAD`; on macOS a `.dylib` via `DYLD_INSERT_LIBRARIES`; on Windows a `.dll` loaded into a frozen process before execution begins.
 
-mirrord-layer is a `.dylib` file for OSX systems and `.so` file on Linux distributions. mirrord-layer is loaded through `LD_PRELOAD/DYLD_INSERT_LIBRARIES` environment variable with the local process, which lets mirrord-layer selectively override libc functions. The overridden functions are then responsible for maintaining coordination between the process and incoming/outgoing requests for network traffic/file access. mirrord-layer sends and receives events from the agent using port-forwarding.
+The layer hooks libc functions (or the Windows-equivalent low-level APIs) for file, socket, DNS, and exec operations. Each intercepted call is either bypassed to the original implementation (for paths that should stay local) or converted into a protocol request and sent to the intproxy.
 
-## mirrord-layer-win
-mirrord-layer-win is a `.dll` file. It is dynamically loaded into the local process, started in a frozen state, and execution begins after the library has been fully initialized. It selectively overrides functions at the lowest level we can get to in user-mode, often right before your operation is dispatched to the kernel through a syscall. The overriden functions are then responsible for maintaining coordination between the process and incoming/outgoing requests for network traffic/file access.
+### `mirrord-intproxy`
 
-## mirrord-cli
+A small local process that sits between the layer(s) and the agent. It exists because:
 
-mirrord-cli is a user friendly interface over the essential functionality provided by the respective mirrord layer. When you run mirrord-cli, it runs the process provided as an argument with the respective mirrord layer loaded into it.
+- The agent connection (port-forward or operator tunnel) is expensive to open per-process. With intproxy, when a target binary forks or execs another mirrord-aware process, the new layer connects to the existing intproxy instead of opening a new agent connection.
+- The layer runs inside the user process where it can't do things like long-running async I/O safely. intproxy owns the agent connection and handles the bookkeeping (request/response matching, reconnects, file-handle state, port subscriptions).
 
-## VS Code Extension
+intproxy is structured as a set of feature-specific proxies (files, incoming, outgoing, DNS, env) that each manage their own state and route messages to/from the agent.
 
-mirrord’s VS Code extension provides mirrord’s functionality within VS Code’s UI. When you debug a process with mirrord enabled in VS Code, it prompts you for a pod to impersonate, then runs the debugged process with the respective mirrord layer loaded into it.
+### `mirrord-agent`
 
-## JetBrains Plugin
+A Rust binary packaged as a container image, run as a Kubernetes pod scheduled on the same node as the target. It joins the target pod's network namespace and mount namespace (`CAP_SYS_ADMIN`) and reads its PID namespace (`CAP_SYS_PTRACE`), giving the agent the same view of networking, filesystem, and process state the target container has.
 
-mirrord’s JetBrains plugin provides mirrord’s functionality within JetBrains IDEs. When you debug a process with mirrord enabled, it prompts you for a pod to impersonate, then runs the debugged process with the respective mirrord layer loaded into it.
+The agent does the actual work: installing iptables redirections for steal subscriptions, opening outgoing sockets, resolving DNS via the pod's resolver, reading `/proc/<target-pid>/environ`, and accessing the container's filesystem via `/proc/<target-pid>/root`.
+
+Required Linux capabilities:
+
+| Capability | Why |
+|---|---|
+| `CAP_NET_ADMIN`, `CAP_NET_RAW` | Modify routing tables, set up traffic mirroring/stealing |
+| `CAP_SYS_PTRACE` | Read the target pod's environment (`/proc/<pid>/environ`) |
+| `CAP_SYS_ADMIN` | Join the target pod's network and mount namespaces |
+
+You can drop any subset via [`agent.disabled_capabilities`](https://metalbear.com/mirrord/docs/config#agent.disabled_capabilities), which will disable the corresponding features.
+
+The agent is **not** privileged — it does not run as root in the cluster sense — and only operates on the targets the user is authorized to access (via Kubernetes RBAC or, for Teams, the operator's policy layer).
+
+### `mirrord-protocol`
+
+Defines the messages exchanged between layer ↔ intproxy ↔ agent: `ClientMessage` (sent by the client side toward the agent) and `DaemonMessage` (sent by the agent back). Serialized with bincode over a TCP connection.
+
+Between the layer and the intproxy there's a separate, lighter local protocol (`mirrord-intproxy-protocol`) with `LayerToProxyMessage` / `ProxyToLayerMessage`.
+
+Backward compatibility is mandatory — the agent, layer, and intproxy ship and upgrade independently, so older clients must keep working against newer agents and vice versa within the supported version window.
+
+### `mirrord-operator` (Teams)
+
+A cluster-wide controller that fronts the agent for Teams users. The operator:
+
+- Resolves targets and authorizes them against the policy layer
+- Allows multiple users to attach to the same workload (and coordinates concurrent steal locks via `on_concurrent_steal`)
+- Provides session sharing primitives for [queue splitting](../sharing-the-cluster/queue-splitting.md), [DB branching](../sharing-the-cluster/db-branching.md), and [profiles](../sharing-the-cluster/profiles.md)
+- Exposes agents over a single tunnel rather than per-user port-forwards
+- Records sessions for audit and visibility ([admin dashboard](../managing-mirrord/admin-dashboard.md))
+
+In OSS, intproxy talks directly to the agent via `kubectl port-forward`. With the operator, intproxy talks to the operator, which proxies to the agent.
+
+### `mirrord-external-proxy` (container mode)
+
+For [`mirrord container`](../using-mirrord/local-container.md) and other scenarios where the user process runs inside a separate container/VM, an additional process — the external proxy — sits between the container boundary and the intproxy. The intproxy runs in the same network namespace as the user process; the external proxy stays on the host and forwards messages between intproxy and agent. Most users never interact with it directly.
+
+## Lifecycle of a `mirrord exec` session
+
+1. **CLI invocation** — `mirrord exec -t <target> -- <command>`. CLI loads config, validates it, and resolves the target via the Kubernetes API.
+2. **Agent setup**:
+   - **OSS path**: CLI creates the agent pod (a `Job`), waits for it to be ready, sets up a port-forward.
+   - **Teams path**: CLI authenticates with the operator, opens a session, and gets back a connection.
+3. **intproxy start**: CLI spawns intproxy as a local subprocess. intproxy connects to the agent (port-forward or operator tunnel).
+4. **Layer injection**: CLI sets `LD_PRELOAD`/`DYLD_INSERT_LIBRARIES`, intproxy address, and config-derived env vars, then execs the user command. The layer initializes immediately on process start.
+5. **Initial fetch**: The layer fetches remote env vars from the agent (synchronous, before the user code runs) and sets them on the process.
+6. **Runtime operations**: Each hooked syscall becomes a `ClientMessage`. intproxy routes it to the agent, the agent executes, and the response (`DaemonMessage`) flows back. The layer translates the response into what the syscall's caller expects.
+7. **Teardown**: When the user process exits, the layer disconnects, intproxy shuts down, and (OSS) the agent pod is deleted, or (Teams) the operator closes the session.
+
+## IDE extensions
+
+The [VS Code extension](../installing-mirrord/vscode.md) and [JetBrains plugin](../installing-mirrord/intellij.md) wrap the same CLI mechanism. They surface a target-picker dialog (when no target is in the config or env), set up the same `LD_PRELOAD`/`DYLD_INSERT_LIBRARIES` injection, and start the debugged process under that environment. From mirrord's perspective there's no difference between a CLI exec and an IDE-launched debug session — the IDE is just a different way of invoking the CLI machinery.
+
+## Related
+
+- [Targets](targets.md) — what kinds of resources can be impersonated
+- [Network Traffic](traffic.md) — how incoming, outgoing, and DNS routing work
+- [File Operations](fileops.md) — how fs syscalls are intercepted and routed
+- [Environment Variables](env.md) — how the env fetch works
+- [Sharing the cluster](../sharing-the-cluster/overview.md) — what the operator unlocks

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -30,19 +30,7 @@ mirrord runs the user's local process unchanged, but rewires its syscalls so fil
 
 In OSS, intproxy talks directly to the agent via `kubectl port-forward`. With the operator, intproxy talks to the operator, which proxies to the agent.
 
-## Agent capabilities
-
-The agent is not privileged (it does not run as root in the cluster sense), but it does need Linux capabilities to impersonate the target pod:
-
-| Capability | Why |
-|---|---|
-| `CAP_NET_ADMIN`, `CAP_NET_RAW` | Modify routing tables, set up traffic mirroring/stealing |
-| `CAP_SYS_PTRACE` | Read the target pod's environment (`/proc/<pid>/environ`) |
-| `CAP_SYS_ADMIN` | Join the target pod's network and mount namespaces |
-
-You can drop any subset via [`agent.disabled_capabilities`](https://metalbear.com/mirrord/docs/config#agent.disabled_capabilities), which will disable the corresponding features.
-
-The agent only operates on the targets the user is authorized to access (via Kubernetes RBAC or, for Teams, the operator's policy layer).
+The agent is not privileged (it does not run as root in the cluster sense), but does need a small set of Linux capabilities to join the target pod's namespaces. See [Security](../managing-mirrord/security.md) for the full list, the RBAC posture, and how to drop individual capabilities via [`agent.disabled_capabilities`](https://metalbear.com/mirrord/docs/config#agent.disabled_capabilities).
 
 ## Related
 

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -66,7 +66,7 @@ mirrord runs the user's local process unchanged, but rewires its syscalls so fil
 
 ### `mirrord-cli`
 
-The user-facing binary. Resolves the target via the Kubernetes API, decides whether to connect through the operator or directly (`operator: false`), launches the intproxy, sets up environment variables (`LD_PRELOAD`/`DYLD_INSERT_LIBRARIES` pointing at the layer library, intproxy address, config-derived feature flags), and `exec`s the user's command. Also fronts the IDE extensions — VS Code and JetBrains plugins call into the same CLI.
+The user-facing binary. Resolves the target via the Kubernetes API, decides whether to connect through the operator or directly (`operator: false`), launches the intproxy, sets up environment variables (`LD_PRELOAD`/`DYLD_INSERT_LIBRARIES` pointing at the layer library, intproxy address, config-derived feature flags), and `exec`s the user's command. Also fronts the IDE extensions: VS Code and JetBrains plugins call into the same CLI.
 
 The CLI does **not** load the layer itself. Loading happens in the next step, driven by the OS dynamic linker.
 
@@ -103,7 +103,7 @@ Required Linux capabilities:
 
 You can drop any subset via [`agent.disabled_capabilities`](https://metalbear.com/mirrord/docs/config#agent.disabled_capabilities), which will disable the corresponding features.
 
-The agent is **not** privileged — it does not run as root in the cluster sense — and only operates on the targets the user is authorized to access (via Kubernetes RBAC or, for Teams, the operator's policy layer).
+The agent is **not** privileged (it does not run as root in the cluster sense) and only operates on the targets the user is authorized to access (via Kubernetes RBAC or, for Teams, the operator's policy layer).
 
 ### `mirrord-protocol`
 
@@ -111,7 +111,7 @@ Defines the messages exchanged between layer ↔ intproxy ↔ agent: `ClientMess
 
 Between the layer and the intproxy there's a separate, lighter local protocol (`mirrord-intproxy-protocol`) with `LayerToProxyMessage` / `ProxyToLayerMessage`.
 
-Backward compatibility is mandatory — the agent, layer, and intproxy ship and upgrade independently, so older clients must keep working against newer agents and vice versa within the supported version window.
+Backward compatibility is mandatory: the agent, layer, and intproxy ship and upgrade independently, so older clients must keep working against newer agents and vice versa within the supported version window.
 
 ### `mirrord-operator` (Teams)
 
@@ -127,28 +127,28 @@ In OSS, intproxy talks directly to the agent via `kubectl port-forward`. With th
 
 ### `mirrord-external-proxy` (container mode)
 
-For [`mirrord container`](../using-mirrord/local-container.md) and other scenarios where the user process runs inside a separate container/VM, an additional process — the external proxy — sits between the container boundary and the intproxy. The intproxy runs in the same network namespace as the user process; the external proxy stays on the host and forwards messages between intproxy and agent. Most users never interact with it directly.
+For [`mirrord container`](../using-mirrord/local-container.md) and other scenarios where the user process runs inside a separate container/VM, an additional process (the external proxy) sits between the container boundary and the intproxy. The intproxy runs in the same network namespace as the user process; the external proxy stays on the host and forwards messages between intproxy and agent. Most users never interact with it directly.
 
 ## Lifecycle of a `mirrord exec` session
 
-1. **CLI invocation** — `mirrord exec -t <target> -- <command>`. CLI loads config, validates it, and resolves the target via the Kubernetes API.
+1. **CLI invocation**: `mirrord exec -t <target> -- <command>`. CLI loads config, validates it, and resolves the target via the Kubernetes API.
 2. **Agent setup**:
    - **OSS path**: CLI creates the agent pod (a `Job`), waits for it to be ready, sets up a port-forward.
    - **Teams path**: CLI authenticates with the operator, opens a session, and gets back a connection.
-3. **intproxy start**: CLI spawns intproxy as a local subprocess. intproxy connects to the agent (port-forward or operator tunnel).
-4. **Layer load**: CLI sets `LD_PRELOAD`/`DYLD_INSERT_LIBRARIES` (pointing at the layer library), the intproxy address, and config-derived env vars, then `exec`s the user command. The OS dynamic linker loads the layer into the new process before its entry point runs; the layer's constructor installs hooks and opens a session with intproxy.
+3. **intproxy start**: CLI spawns intproxy as a local subprocess with the CLI's normal environment (no `LD_PRELOAD`). intproxy is a regular process; nothing is injected into it. It binds a local socket (TCP or Unix) and connects out to the agent (port-forward or operator tunnel).
+4. **Layer load**: CLI `exec`s the user command, passing a **per-exec** augmented environment: `LD_PRELOAD`/`DYLD_INSERT_LIBRARIES` (pointing at the layer library), `MIRRORD_INTPROXY_ADDR` (the address from step 3), and config-derived feature flags. These vars never live on the CLI's own process environment, so they don't leak into intproxy or any other sibling process. The OS dynamic linker reads `LD_PRELOAD` from the new process's environment and loads the layer into the user process before its entry point runs; the layer's constructor installs hooks and connects to intproxy at `MIRRORD_INTPROXY_ADDR`. (Any subprocess the user app later spawns inherits `LD_PRELOAD` from the user app's environment, so it also gets the layer loaded — and connects to the same intproxy.)
 5. **Initial fetch**: The layer fetches remote env vars from the agent (synchronous, before the user code runs) and sets them on the process.
 6. **Runtime operations**: Each hooked syscall becomes a `ClientMessage`. intproxy routes it to the agent, the agent executes, and the response (`DaemonMessage`) flows back. The layer translates the response into what the syscall's caller expects.
 7. **Teardown**: When the user process exits, the layer disconnects, intproxy shuts down, and (OSS) the agent pod is deleted, or (Teams) the operator closes the session.
 
 ## IDE extensions
 
-The [VS Code extension](../installing-mirrord/vscode.md) and [JetBrains plugin](../installing-mirrord/intellij.md) wrap the same CLI mechanism. They surface a target-picker dialog (when no target is in the config or env), set up the same `LD_PRELOAD`/`DYLD_INSERT_LIBRARIES` injection, and start the debugged process under that environment. From mirrord's perspective there's no difference between a CLI exec and an IDE-launched debug session — the IDE is just a different way of invoking the CLI machinery.
+The [VS Code extension](../installing-mirrord/vscode.md) and [JetBrains plugin](../installing-mirrord/intellij.md) wrap the same CLI mechanism. They surface a target-picker dialog (when no target is in the config or env), set up the same `LD_PRELOAD`/`DYLD_INSERT_LIBRARIES` injection, and start the debugged process under that environment. From mirrord's perspective there's no difference between a CLI exec and an IDE-launched debug session. The IDE is just a different way of invoking the CLI machinery.
 
 ## Related
 
-- [Targets](targets.md) — what kinds of resources can be impersonated
-- [Network Traffic](traffic.md) — how incoming, outgoing, and DNS routing work
-- [File Operations](fileops.md) — how fs syscalls are intercepted and routed
-- [Environment Variables](env.md) — how the env fetch works
-- [Sharing the cluster](../sharing-the-cluster/overview.md) — what the operator unlocks
+- [Targets](targets.md): what kinds of resources can be impersonated
+- [Network Traffic](traffic.md): how incoming, outgoing, and DNS routing work
+- [File Operations](fileops.md): how fs syscalls are intercepted and routed
+- [Environment Variables](env.md): how the env fetch works
+- [Sharing the cluster](../sharing-the-cluster/overview.md): what the operator unlocks

--- a/docs/reference/env.md
+++ b/docs/reference/env.md
@@ -16,76 +16,143 @@ tags:
 description: Reference to including remote environment variables
 ---
 
-## Overview
+mirrord makes the target pod's environment available to the local process. This page describes how the feature works end-to-end, the full configuration surface, the always-excluded variables, and the gotchas worth knowing.
 
-mirrord lets you run a local process in the context of remote environment i.e. environment variables present in the remote pod will be loaded into the local process.
+For the quick how-to, see [Using mirrord → Environment Variables](../using-mirrord/environment-variables.md).
 
-For example, if you want your local process to access a remote database, the connection string configured in the remote pod's environment variable can be used by your local process.
+## How it works
 
-## How does it work?
+![mirrord - env vars](env/mirrord-env-vars.png)
 
-![mirrord - fileops](env/mirrord-env-vars.png)
-
-mirrord-layer sends a message to mirrord-agent requesting remote environment variables, which are then set before the local process starts.
-
-## Usage
-
-To include/exclude environment variables selectively, use the `--override-env-vars-include` flag to include and `--override-env-vars-exclude` to exclude with environment variables specified in a `semicolon` separated list.
-
-> **Note:** These flags are mutually exclusive. For example, if one chooses to exclude using the `--override-env-vars-exclude` flag, then there is no need to use `--override-env-vars-include="*"` to include all other environment variables.
-
-By default, all environment variables are included.
-
-**Example**
-
-If on our target pod, we have the environment variable `ENV_VAR1` with the value `remote-value` and on our local machine we have `ENV_VAR1` with value `local-value`, then Running the python interpreter with mirrord would look like this:
-
-```bash
-MIRRORD_AGENT_IMAGE=test MIRRORD_AGENT_RUST_LOG=trace RUST_LOG=debug target/debug/mirrord exec -c --target pod/py-serv-deployment-ff89b5974-x9tjx python3
-
-Python 3.9.13 (v3.9.13:6de2ca5339, May 17 2022, 11:23:25)
-[Clang 6.0 (clang-600.0.57)] on darwin
-Type "help", "copyright", "credits" or "license" for more information.
->>> import os
->>> print(os.environ['ENV_VAR1'])
-remote-value
+```
+┌──────────────────────────┐
+│ Local process            │
+│ ┌──────────────────────┐ │
+│ │ mirrord-layer        │ │  Before the process starts, the
+│ │   fetch_env_vars()   │ │  layer asks the agent for the
+│ └──────────┬───────────┘ │  target pod's env.
+└────────────┼─────────────┘
+             │ GetEnvVarsRequest
+             │   { env_vars_select, env_vars_filter }
+┌────────────▼─────────────┐
+│ mirrord-intproxy         │  Routes the request to the agent.
+└────────────┬─────────────┘
+             │
+┌────────────▼─────────────┐
+│ mirrord-agent            │  Reads `/proc/<pid>/environ` of the
+│   select_env_vars()      │  target container's main process,
+└────────────┬─────────────┘  applies include + exclude filters.
+             │ GetEnvVarsResponse
+             ▼
+        full env map
 ```
 
-Logs
+Once the layer has the map, it applies four post-fetch transformations in this order:
 
-```bash
-❯ MIRRORD_AGENT_IMAGE=test MIRRORD_AGENT_RUST_LOG=trace RUST_LOG=debug target/debug/mirrord exec -c --target pod/py-serv-deployment-ff89b5974-x9tjx python3
-...
-2022-07-01T17:18:33.744996Z DEBUG mirrord_layer: ClientMessage::GetEnvVarsRequest codec_result Ok(
-    (),
-)
-2022-07-01T17:18:33.754270Z DEBUG mirrord_layer: DaemonMessage::GetEnvVarsResponse Ok(
-    {
-        "KUBERNETES_PORT": "tcp://10.96.0.1:443",
-        "LANG": "C.UTF-8",
-        "KUBERNETES_SERVICE_PORT": "443",
-        "PY_SERV_PORT": "tcp://10.96.139.36:80",
-        "KUBERNETES_PORT_443_TCP": "tcp://10.96.0.1:443",
-        "PY_SERV_SERVICE_PORT": "80",
-        "KUBERNETES_SERVICE_PORT_HTTPS": "443",
-        "PYTHON_SETUPTOOLS_VERSION": "58.1.0",
-        "PY_SERV_PORT_80_TCP_ADDR": "10.96.139.36",
-        "PYTHON_GET_PIP_SHA256": "ba3ab8267d91fd41c58dbce08f76db99f747f716d85ce1865813842bb035524d",
-        "ENV_VAR1": "remote-value",
-        "KUBERNETES_SERVICE_HOST": "10.96.0.1",
-        "KUBERNETES_PORT_443_TCP_PORT": "443",
-        "HOSTNAME": "py-serv-deployment-ff89b5974-x9tjx",
-        "KUBERNETES_PORT_443_TCP_ADDR": "10.96.0.1",
-        "GPG_KEY": "E3FF2839C048B25C084DEBE9B26995E310250568",
-        "PYTHON_GET_PIP_URL": "https://github.com/pypa/get-pip/raw/6ce3639da143c5d79b44f94b04080abf2531fd6e/public/get-pip.py",
-        "PY_SERV_PORT_80_TCP": "tcp://10.96.139.36:80",
-        "KUBERNETES_PORT_443_TCP_PROTO": "tcp",
-        "PYTHON_VERSION": "3.9.13",
-        "PY_SERV_PORT_80_TCP_PROTO": "tcp",
-        "PY_SERV_PORT_80_TCP_PORT": "80",
-        "PY_SERV_SERVICE_HOST": "10.96.139.36",
-        "PYTHON_PIP_VERSION": "22.0.4",
-    },
-)!
-...
+1. **`env_file`** — merge variables from the dotenv file specified by `env_file` (overrides remote values).
+2. **`mapping`** — apply regex-based value replacement.
+3. **`override`** — apply user-specified key/value overrides (final word).
+4. The resulting environment is set on the process before its entry point runs.
+
+For frameworks where the env can't be modified from inside the process (notably Go), `unset` runs from the CLI/extension before exec.
+
+## Configuration surface
+
+```json
+{
+  "feature": {
+    "env": {
+      "include": "DATABASE_URL;PUBLIC_*",
+      "exclude": "SECRET_*",
+      "override": {
+        "REGION": "us-east-1"
+      },
+      "env_file": "./.env.local",
+      "mapping": {
+        ".+_TIMEOUT": "10000"
+      },
+      "unset": ["AWS_PROFILE"],
+      "load_from_process": false
+    }
+  }
+}
 ```
+
+| Field | Type | Default | Behavior |
+|---|---|---|---|
+| `include` | string \| array | — | Allowlist. Supports `*` and `?` wildcards. Mutually exclusive with `exclude`. |
+| `exclude` | string \| array | — | Denylist applied on top of the [built-in always-excluded list](#always-excluded-variables). Mutually exclusive with `include`. |
+| `override` | object | — | Key/value pairs set on the local process. Wins over remote values and `env_file`. |
+| `env_file` | path | — | Dotenv file merged into the remote env. Values override the remote ones. |
+| `mapping` | object | — | Regex → replacement applied to **values** (not keys). Capture groups allowed. |
+| `unset` | string \| array | — | Variables removed entirely. Case-insensitive. Required for Go (env can't be modified post-start). |
+| `load_from_process` | bool | `false` | Fetch env after the user process starts instead of before. WSL+IntelliJ workaround when the remote env is very large. |
+
+### `include` and `exclude` are mutually exclusive
+
+Setting both causes the layer to panic at startup. Use one or the other.
+
+When neither is set, the layer requests `*` (all remote variables).
+
+### Wildcard syntax
+
+`include` and `exclude` use `wildmatch` (not regex):
+
+- `*` — zero or more of any character
+- `?` — exactly one of any character
+
+Use the `mapping` field if you need full regex on values.
+
+### `mapping` operates on values, not keys
+
+The pattern is matched against each variable's **value**; the replacement becomes the new value. Capture groups are supported via standard Rust `regex` `replace` syntax (`$1`, `${name}`).
+
+## Always-excluded variables
+
+The agent always strips these from the response, regardless of what `include` requests. This prevents the remote pod's toolchain paths from breaking the local interpreter/runtime.
+
+```
+BUNDLER_ORIG_BUNDLER_ORIG_MANPATH    GEM_HOME            PATH
+BUNDLER_ORIG_BUNDLER_VERSION         GEM_PATH            PWD
+BUNDLER_ORIG_BUNDLE_BIN_PATH         GOMODCACHE          PYTHONPATH
+BUNDLER_ORIG_BUNDLE_GEMFILE          GOPATH              RUBYLIB
+BUNDLER_ORIG_GEM_HOME                HOME                RUBYOPT
+BUNDLER_ORIG_MANPATH                 HOMEPATH            RUST_LOG
+BUNDLER_ORIG_PATH                    JAVA_EXE            _JAVA_OPTIONS
+BUNDLER_ORIG_RB_USER_INSTALL         JAVA_HOME
+BUNDLER_ORIG_RUBYLIB                 JAVA_TOOL_OPTIONS
+BUNDLER_ORIG_RUBYOPT
+BUNDLER_VERSION
+BUNDLE_APP_CONFIG / _BIN_PATH /
+  _FORCE_RUBY_PLATFORM / _GEMFILE /
+  _GEM_PATH / _PATH / _WITHOUT
+CATALINA_HOME                        DOTNET_EnableDiagnostics
+CLASSPATH                            DOTNET_STARTUP_HOOKS
+```
+
+User-supplied `exclude` patterns are **added to** this list — they do not replace it.
+
+The canonical list lives in `mirrord-agent/src/env.rs`.
+
+## How the agent reads the env
+
+The agent enters the target container's PID namespace and reads `/proc/<target-pid>/environ` (NUL-delimited `KEY=VALUE` pairs). It does **not** spawn anything in the container — there's no exec, no shell evaluation. What you get is exactly what was set on the process at start (so runtime `os.setenv()` calls inside the pod won't show up).
+
+This is also why containers running things like nginx, which rewrite `/proc/self/environ` after start, can return surprising results.
+
+## Equivalent environment variables
+
+Each config field has a matching env var, useful from CLI/CI:
+
+| Config | Env var |
+|---|---|
+| `feature.env.include` | `MIRRORD_OVERRIDE_ENV_VARS_INCLUDE` |
+| `feature.env.exclude` | `MIRRORD_OVERRIDE_ENV_VARS_EXCLUDE` |
+| `feature.env.env_file` | `MIRRORD_OVERRIDE_ENV_VARS_FILE` |
+| `feature.env.load_from_process` | `MIRRORD_ENV_LOAD_FROM_PROCESS` |
+
+## Related
+
+- [`feature.env` config reference](https://metalbear.com/mirrord/docs/config#feature.env) — full schema
+- [Architecture](architecture.md) — layer/intproxy/agent message flow
+- [Using mirrord → Environment Variables](../using-mirrord/environment-variables.md) — quick how-to

--- a/docs/reference/env.md
+++ b/docs/reference/env.md
@@ -16,47 +16,13 @@ tags:
 description: Reference to including remote environment variables
 ---
 
-mirrord makes the target pod's environment available to the local process. This page describes how the feature works end-to-end, the full configuration surface, the always-excluded variables, and the gotchas worth knowing.
+mirrord makes the target pod's environment available to the local process. Before the user process starts, the layer requests the env from the agent, which reads `/proc/<target-pid>/environ` inside the target container and returns the filtered set. The layer then applies any user-specified overrides and sets the result on the process.
 
 For the quick how-to, see [Using mirrord → Environment Variables](../using-mirrord/environment-variables.md).
 
-## How it works
-
 ![mirrord - env vars](env/mirrord-env-vars.png)
 
-```
-┌──────────────────────────┐
-│ Local process            │
-│ ┌──────────────────────┐ │
-│ │ mirrord-layer        │ │  Before the process starts, the
-│ │   fetch_env_vars()   │ │  layer asks the agent for the
-│ └──────────┬───────────┘ │  target pod's env.
-└────────────┼─────────────┘
-             │ GetEnvVarsRequest
-             │   { env_vars_select, env_vars_filter }
-┌────────────▼─────────────┐
-│ mirrord-intproxy         │  Routes the request to the agent.
-└────────────┬─────────────┘
-             │
-┌────────────▼─────────────┐
-│ mirrord-agent            │  Reads `/proc/<pid>/environ` of the
-│   select_env_vars()      │  target container's main process,
-└────────────┬─────────────┘  applies include + exclude filters.
-             │ GetEnvVarsResponse
-             ▼
-        full env map
-```
-
-Once the layer has the map, it applies four post-fetch transformations in this order:
-
-1. **`env_file`**: merge variables from the dotenv file specified by `env_file` (overrides remote values).
-2. **`mapping`**: apply regex-based value replacement.
-3. **`override`**: apply user-specified key/value overrides (final word).
-4. The resulting environment is set on the process before its entry point runs.
-
-For frameworks where the env can't be modified from inside the process (notably Go), `unset` runs from the CLI/extension before exec.
-
-## Configuration surface
+## Configuration
 
 ```json
 {
@@ -78,34 +44,17 @@ For frameworks where the env can't be modified from inside the process (notably 
 }
 ```
 
-| Field | Type | Default | Behavior |
-|---|---|---|---|
-| `include` | string \| array | none | Allowlist. Supports `*` and `?` wildcards. Mutually exclusive with `exclude`. |
-| `exclude` | string \| array | none | Denylist applied on top of the [built-in always-excluded list](#always-excluded-variables). Mutually exclusive with `include`. |
-| `override` | object | none | Key/value pairs set on the local process. Wins over remote values and `env_file`. |
-| `env_file` | path | none | Dotenv file merged into the remote env. Values override the remote ones. |
-| `mapping` | object | none | Regex → replacement applied to **values** (not keys). Capture groups allowed. |
-| `unset` | string \| array | none | Variables removed entirely. Case-insensitive. Required for Go (env can't be modified post-start). |
-| `load_from_process` | bool | `false` | Fetch env after the user process starts instead of before. WSL+IntelliJ workaround when the remote env is very large. |
+| Field | Behavior |
+|---|---|
+| `include` | Allowlist. Supports `*` and `?` wildcards. Mutually exclusive with `exclude`. |
+| `exclude` | Denylist applied on top of the [built-in always-excluded list](#always-excluded-variables). Mutually exclusive with `include`. |
+| `override` | Key/value pairs set on the local process. Wins over remote values and `env_file`. |
+| `env_file` | Dotenv file merged into the remote env. Values override the remote ones. |
+| `mapping` | Regex → replacement applied to **values** (not keys). Capture groups allowed. |
+| `unset` | Variables removed entirely. Case-insensitive. Required for Go (env can't be modified post-start). |
+| `load_from_process` | Fetch env after the user process starts instead of before. WSL+IntelliJ workaround when the remote env is very large. Defaults to `false`. |
 
-### `include` and `exclude` are mutually exclusive
-
-Setting both causes the layer to panic at startup. Use one or the other.
-
-When neither is set, the layer requests `*` (all remote variables).
-
-### Wildcard syntax
-
-`include` and `exclude` use `wildmatch` (not regex):
-
-- `*`: zero or more of any character
-- `?`: exactly one of any character
-
-Use the `mapping` field if you need full regex on values.
-
-### `mapping` operates on values, not keys
-
-The pattern is matched against each variable's **value**; the replacement becomes the new value. Capture groups are supported via standard Rust `regex` `replace` syntax (`$1`, `${name}`).
+`include` and `exclude` are mutually exclusive; setting both causes the layer to panic at startup. When neither is set, the layer requests all variables.
 
 ## Always-excluded variables
 
@@ -132,13 +81,7 @@ CLASSPATH                            DOTNET_STARTUP_HOOKS
 
 User-supplied `exclude` patterns are **added to** this list; they do not replace it.
 
-The canonical list lives in `mirrord-agent/src/env.rs`.
-
-## How the agent reads the env
-
-The agent enters the target container's PID namespace and reads `/proc/<target-pid>/environ` (NUL-delimited `KEY=VALUE` pairs). It does **not** spawn anything in the container: no exec, no shell evaluation. What you get is exactly what was set on the process at start (so runtime `os.setenv()` calls inside the pod won't show up).
-
-This is also why containers running things like nginx, which rewrite `/proc/self/environ` after start, can return surprising results.
+The canonical list lives in [`mirrord-agent/src/env.rs`](https://github.com/metalbear-co/mirrord/blob/latest/mirrord/agent/src/env.rs).
 
 ## Equivalent environment variables
 
@@ -154,5 +97,4 @@ Each config field has a matching env var, useful from CLI/CI:
 ## Related
 
 - [`feature.env` config reference](https://metalbear.com/mirrord/docs/config#feature.env): full schema
-- [Architecture](architecture.md): layer/intproxy/agent message flow
 - [Using mirrord → Environment Variables](../using-mirrord/environment-variables.md): quick how-to

--- a/docs/reference/env.md
+++ b/docs/reference/env.md
@@ -49,9 +49,9 @@ For the quick how-to, see [Using mirrord → Environment Variables](../using-mir
 
 Once the layer has the map, it applies four post-fetch transformations in this order:
 
-1. **`env_file`** — merge variables from the dotenv file specified by `env_file` (overrides remote values).
-2. **`mapping`** — apply regex-based value replacement.
-3. **`override`** — apply user-specified key/value overrides (final word).
+1. **`env_file`**: merge variables from the dotenv file specified by `env_file` (overrides remote values).
+2. **`mapping`**: apply regex-based value replacement.
+3. **`override`**: apply user-specified key/value overrides (final word).
 4. The resulting environment is set on the process before its entry point runs.
 
 For frameworks where the env can't be modified from inside the process (notably Go), `unset` runs from the CLI/extension before exec.
@@ -80,12 +80,12 @@ For frameworks where the env can't be modified from inside the process (notably 
 
 | Field | Type | Default | Behavior |
 |---|---|---|---|
-| `include` | string \| array | — | Allowlist. Supports `*` and `?` wildcards. Mutually exclusive with `exclude`. |
-| `exclude` | string \| array | — | Denylist applied on top of the [built-in always-excluded list](#always-excluded-variables). Mutually exclusive with `include`. |
-| `override` | object | — | Key/value pairs set on the local process. Wins over remote values and `env_file`. |
-| `env_file` | path | — | Dotenv file merged into the remote env. Values override the remote ones. |
-| `mapping` | object | — | Regex → replacement applied to **values** (not keys). Capture groups allowed. |
-| `unset` | string \| array | — | Variables removed entirely. Case-insensitive. Required for Go (env can't be modified post-start). |
+| `include` | string \| array | none | Allowlist. Supports `*` and `?` wildcards. Mutually exclusive with `exclude`. |
+| `exclude` | string \| array | none | Denylist applied on top of the [built-in always-excluded list](#always-excluded-variables). Mutually exclusive with `include`. |
+| `override` | object | none | Key/value pairs set on the local process. Wins over remote values and `env_file`. |
+| `env_file` | path | none | Dotenv file merged into the remote env. Values override the remote ones. |
+| `mapping` | object | none | Regex → replacement applied to **values** (not keys). Capture groups allowed. |
+| `unset` | string \| array | none | Variables removed entirely. Case-insensitive. Required for Go (env can't be modified post-start). |
 | `load_from_process` | bool | `false` | Fetch env after the user process starts instead of before. WSL+IntelliJ workaround when the remote env is very large. |
 
 ### `include` and `exclude` are mutually exclusive
@@ -98,8 +98,8 @@ When neither is set, the layer requests `*` (all remote variables).
 
 `include` and `exclude` use `wildmatch` (not regex):
 
-- `*` — zero or more of any character
-- `?` — exactly one of any character
+- `*`: zero or more of any character
+- `?`: exactly one of any character
 
 Use the `mapping` field if you need full regex on values.
 
@@ -130,13 +130,13 @@ CATALINA_HOME                        DOTNET_EnableDiagnostics
 CLASSPATH                            DOTNET_STARTUP_HOOKS
 ```
 
-User-supplied `exclude` patterns are **added to** this list — they do not replace it.
+User-supplied `exclude` patterns are **added to** this list; they do not replace it.
 
 The canonical list lives in `mirrord-agent/src/env.rs`.
 
 ## How the agent reads the env
 
-The agent enters the target container's PID namespace and reads `/proc/<target-pid>/environ` (NUL-delimited `KEY=VALUE` pairs). It does **not** spawn anything in the container — there's no exec, no shell evaluation. What you get is exactly what was set on the process at start (so runtime `os.setenv()` calls inside the pod won't show up).
+The agent enters the target container's PID namespace and reads `/proc/<target-pid>/environ` (NUL-delimited `KEY=VALUE` pairs). It does **not** spawn anything in the container: no exec, no shell evaluation. What you get is exactly what was set on the process at start (so runtime `os.setenv()` calls inside the pod won't show up).
 
 This is also why containers running things like nginx, which rewrite `/proc/self/environ` after start, can return surprising results.
 
@@ -153,6 +153,6 @@ Each config field has a matching env var, useful from CLI/CI:
 
 ## Related
 
-- [`feature.env` config reference](https://metalbear.com/mirrord/docs/config#feature.env) — full schema
-- [Architecture](architecture.md) — layer/intproxy/agent message flow
-- [Using mirrord → Environment Variables](../using-mirrord/environment-variables.md) — quick how-to
+- [`feature.env` config reference](https://metalbear.com/mirrord/docs/config#feature.env): full schema
+- [Architecture](architecture.md): layer/intproxy/agent message flow
+- [Using mirrord → Environment Variables](../using-mirrord/environment-variables.md): quick how-to

--- a/docs/reference/fileops.md
+++ b/docs/reference/fileops.md
@@ -13,123 +13,138 @@ toc: true
 tags: ["open source", "team", "enterprise"]
 ---
 
-## Overview
+mirrord intercepts file syscalls in the local process and routes them to the target pod, so the local app sees the same `/etc/`, `/var/`, mounted ConfigMaps, mounted Secrets, and volume contents the deployed pod does. This page covers what gets intercepted, the four fs modes, the override/pattern system, and the agent-side mechanism.
 
-mirrord will relay file access (except for some exceptions ([Unix](https://github.com/metalbear-co/mirrord/blob/main/mirrord/layer-lib/src/file/unix/read_local_by_default.rs) | [Windows](https://github.com/metalbear-co/mirrord/blob/main/mirrord/layer-lib/src/file/windows/read_local_by_default.rs))) to the
-target pod by default. This functionality is controlled by the `feature.fs.mode` configuration option (or the `--fs-mode` CLI flag).
-
-### Modes
-
-| Mode | Behavior |
-|------|----------|
-| `local` | All file operations happen on the local filesystem. mirrord doesn't touch fs syscalls. |
-| `localwithoverrides` | Mostly local, but mirrord still applies its built-in overrides for a small set of paths (the default exception lists linked above). |
-| `read` *(default)* | Reads go to the remote pod, writes go to the local filesystem. |
-| `write` | Both reads and writes go to the remote pod. |
-
-User overrides and mirrord's default overrides apply on top of the selected mode — for instance, `read` mode will still resolve a handful of paths locally (DNS files, the user's home directory, etc.).
-
-For example, the following python script calls the built-in `open` function which translate to something like
-`openat(AT_FDCWD, "/tmp/test", O_RDWR|O_CLOEXEC)` at a lower level:
-
-```py
-with open("/tmp/test", "r+") as rw_file:
-    read_str = rw_file.read(42)
-print(read_str)
-```
-
-When we run that python script with mirrord:
-
-```bash
-mirrord exec -c --target py-serv-deployment-cfc458fd4-bjzjx python3 test.py
-```
-
-mirrord overrides that `openat` call and opens `/tmp/test` on the remote pod.
-
-## How does it work?
+For the how-to version, see [Using mirrord → File Operations](../using-mirrord/file-operations.md).
 
 ![mirrord - fileops](/reference/fileops/mirrord-fileops.png)
 
-Once a request to open a new file is received by `mirrord-agent` from `mirrord-layer`, the agent forwards the request
-to the container in the remote pod in context of the provided path for the open system call, prefixed with path to the
-root directory of the container.
+## The four `fs` modes
 
-`mirrord-agent` uses APIs provided by docker and containerd runtimes to get the PID of the remote container, and
-refers to the root directory of the remote container through `/proc/container_pid/root`
+Set via `feature.fs.mode`:
 
-## Syscalls
+| Mode | Reads | Writes | Notes |
+|---|---|---|---|
+| `local` | local | local | mirrord does nothing — no fs syscalls are intercepted. Equivalent to `feature.fs: false`. |
+| `localwithoverrides` | local (except overrides) | local (except overrides) | Default behavior is local; only paths matching `read_only`, `read_write`, or the [pre-defined remote-by-default list](#default-overrides) go to the remote pod. |
+| `read` *(default)* | remote (except overrides) | local | Reads come from the pod; writes stay local. Safest mode — you can't accidentally modify the cluster. |
+| `write` | remote (except overrides) | remote | Reads and writes both go to the pod. Use with care — writes hit the real remote filesystem. |
 
-mirrord overrirdes calls to the following libc functions/system calls:
+Shorthand: `"fs": "read"`, `"fs": false` (= `local`), `"fs": true` (= `write`).
 
-### open
+## Configuration surface
 
-`int open(const char *pathname, int flags);`
-
-Open files on the remote pod. Functionality when opening with different types of paths might differ. In the case when
-`pathname` is specified to be a relative path, the call to open is sent to libc instead of the remote pod.
-
-Example:
-
-```py
-import os
-fd = os.open("/tmp/test", os.O_WRONLY | os.O_CREAT)
+```json
+{
+  "feature": {
+    "fs": {
+      "mode": "read",
+      "read_write":  [".+\\.json"],
+      "read_only":   ["/etc/config/.+"],
+      "local":       ["/tmp/.+", ".+\\.lock"],
+      "not_found":   ["\\.config/gcloud"],
+      "mapping": {
+        "^/home/(?<user>[^/]+)/dev/config/(?<app>[^/]+)": "/mnt/configs/${user}-${app}"
+      },
+      "readonly_file_buffer": 128000
+    }
+  }
+}
 ```
 
-### openat
+| Field | Behavior |
+|---|---|
+| `mode` | One of `local`, `localwithoverrides`, `read`, `write`. See above. |
+| `read_write` | Regex patterns. Matching paths always go to the remote pod, read and write. |
+| `read_only` | Regex patterns. Matching paths read from the remote pod; writes go local. |
+| `local` | Regex patterns. Matching paths always stay local, regardless of mode. |
+| `not_found` | Regex patterns. Matching paths return `ENOENT` to the application — useful for hiding files that exist locally but would confuse a cluster-context process (e.g. `~/.aws/credentials`). |
+| `mapping` | Regex → replacement applied to the path **before** routing. Capture groups are supported (`$1`, `${name}`). Useful when local paths don't match remote paths (common on Windows). |
+| `readonly_file_buffer` | Buffer size in bytes for read-only remote files. Default `128000` (128 kB). Set `0` to disable buffering. Hard limit 15 MB. |
 
-`int openat(int dirfd, const char *pathname, int flags);`
+All pattern lists are case-insensitive. If a path matches more than one list, the **first** match wins — order across lists is not guaranteed, so don't put the same path in two lists.
 
-`openat` works the same as `open` when `dirfd` is specified as `AT_FDCWD` or if the path is absolute. If a valid
-`dirfd` is provided, files relative to the directory referred to by the `dirfd` can be opened.
+## Resolution order
 
-Example:
+For each fs syscall the layer intercepts, mirrord resolves the routing in this order:
 
-```py
-dir = os.open("/tmp", os.O_RDONLY | os.O_NONBLOCK | os.O_CLOEXEC | os.O_DIRECTORY)
+1. **`mapping`** — if the path matches a `mapping` entry, replace it before proceeding.
+2. **User pattern lists** — `read_write`, `read_only`, `local`, `not_found`. First match wins.
+3. **[Default overrides](#default-overrides)** — built-in lists that override the mode for specific paths regardless of user config.
+4. **`mode`** — the fallback routing for paths nothing else matched.
 
-os.open("test", os.O_RDWR | os.O_NONBLOCK | os.O_CLOEXEC, dir_fd=dir)
+## Default overrides
+
+mirrord ships built-in pattern lists that override the active mode. These exist so the local interpreter, package manager, and home-directory state aren't broken by remote-by-default routing.
+
+| List | Effect | Source |
+|---|---|---|
+| Local-by-default | Always read locally, regardless of mode | [`unix`](https://github.com/metalbear-co/mirrord/blob/latest/mirrord/layer-lib/src/file/unix/read_local_by_default.rs) · [`windows`](https://github.com/metalbear-co/mirrord/blob/latest/mirrord/layer-lib/src/file/windows/read_local_by_default.rs) |
+| Remote-by-default (when mode is `localwithoverrides`) | Read remotely even though mode says local | [`unix`](https://github.com/metalbear-co/mirrord/blob/latest/mirrord/layer-lib/src/file/unix/read_remote_by_default.rs) · [`windows`](https://github.com/metalbear-co/mirrord/blob/latest/mirrord/layer-lib/src/file/windows/read_remote_by_default.rs) |
+| Not-found-by-default (under `$HOME`, all modes except `local`) | Always `ENOENT` | [`unix`](https://github.com/metalbear-co/mirrord/blob/latest/mirrord/layer-lib/src/file/unix/not_found_by_default.rs) · [`windows`](https://github.com/metalbear-co/mirrord/blob/latest/mirrord/layer-lib/src/file/windows/not_found_by_default.rs) |
+
+To override a default — for example, to read `/etc/` remotely even though it's local-by-default — add it to the appropriate user list: `"read_only": ["^/etc/.+"]`.
+
+## Intercepted syscalls
+
+mirrord hooks the following libc functions on Linux/macOS. The layer intercepts each call, decides local vs. remote based on the [resolution order](#resolution-order), and either bypasses to the original libc function or sends a request to the agent.
+
+| Category | Hooked |
+|---|---|
+| Open | `open`, `open64`, `openat`, `opendir`, `dirfd` |
+| Read | `read`, `readv`, `pread`, `preadv`, `readlink`, `readdir`, `readdir64`, `readdir_r`, `readdir64_r` |
+| Write | `write`, `pwrite` |
+| Position | `lseek` |
+| Metadata | `access`, `stat`, `lstat`, `statx`, `statfs`, `statvfs`, `fstat`, `fstatat`, `fstatfs`, `fchmod`, `fchown`, `fsync` |
+| Directory | `mkdir`, `rmdir` |
+| Path | `rename`, `unlink`, `unlinkat` |
+
+On macOS the layer also hooks the `_NOCANCEL` and `$INODE64` variants where applicable. The full, current list lives in [`mirrord/layer/src/file/hooks.rs`](https://github.com/metalbear-co/mirrord/blob/latest/mirrord/layer/src/file/hooks.rs).
+
+Windows has its own equivalent hook set in `mirrord-layer-win`.
+
+### Relative path behavior
+
+When a hooked syscall receives a relative path with no anchoring directory fd, the call is **bypassed to libc** (i.e. resolved locally). This avoids ambiguity, since the layer can't know the remote pod's working directory.
+
+`openat` with a valid `dirfd` returned by a previous remote `open` follows the remote directory; with `AT_FDCWD` it behaves like `open`.
+
+### File descriptor disambiguation
+
+`read`, `write`, `lseek`, `stat`, etc. take an fd. The layer maintains a map of fds that belong to remote-opened files. If the fd is a remote one, the call is sent to the agent; otherwise it's bypassed to libc. This means closing and reopening a file with the same path can flip its routing if config or mode changed in between.
+
+## How the agent reads files
+
+```
+┌──────────────────────────┐
+│ Local process            │
+│ ┌──────────────────────┐ │
+│ │   mirrord-layer      │ │  Hooks open/read/write/...
+│ └──────────┬───────────┘ │  Sends FileRequest to intproxy.
+└────────────┼─────────────┘
+             │ FileRequest::Open / Read / Write / ...
+┌────────────▼─────────────┐
+│ mirrord-intproxy         │
+└────────────┬─────────────┘
+             │
+┌────────────▼─────────────┐
+│ mirrord-agent            │  Resolves the target container's
+│   (target netns + mntns) │  rootfs via `/proc/<pid>/root`
+│                          │  and performs the operation
+│                          │  against that path.
+└──────────────────────────┘
 ```
 
-### read
+The agent uses the container runtime's API (containerd, docker, CRI-O) to get the PID of the target container. It then accesses the container's filesystem through `/proc/<container-pid>/root`, which gives it the view of the mount namespace the container sees — including ConfigMap/Secret mounts and persistent volumes.
 
-`ssize_t read(int fd, void *buf, size_t count);`
+The agent does not exec inside the container; it reads/writes from the agent pod with the kernel doing the namespace translation. This is why the agent needs `CAP_SYS_ADMIN` (joining mount/PID namespaces).
 
-Read from a file on the remote pod.
+### inotify and file watches
 
-Example:
+mirrord does not currently intercept `inotify`/`fanotify` syscalls. Applications watching ConfigMap/Secret mounts for changes won't see remote modifications. Workaround: poll the file's mtime via `stat`.
 
-```py
-fd = os.open("/tmp/test", os.O_RDWR | os.O_NONBLOCK | os.O_CLOEXEC)
-read = os.read(fd, 1024)
-```
+## Related
 
-### write
-
-`ssize_t write(int fd, const void *buf, size_t count);`
-
-Write to a file on the remote pod.
-
-Example:
-
-```py
-with open("/tmp/test", "w") as file:
-    file.write(TEXT)
-```
-
-### lseek
-
-`off_t lseek(int fd, off_t offset, int whence);`
-
-Reposition the file offset of an open file on the remote pod. lseek through mirrord-layer supports all valid options
-for whence as specified in the Linux manpages.
-
-Example:
-
-```py
-with open("/tmp/test", "w") as file:
-    file.seek(10)
-    file.write(TEXT)
-```
-
-> **Note:** For read, write, and lseek if the provided `fd` is a valid file descriptor i.e. it refers to a file
-> opened on the remote pod then the call is forwarded to the remote pod, otherwise the call is sent to libc.
+- [`feature.fs` config reference](https://metalbear.com/mirrord/docs/config#feature.fs) — full schema
+- [Architecture](architecture.md) — layer / intproxy / agent
+- [Using mirrord → File Operations](../using-mirrord/file-operations.md) — quick how-to

--- a/docs/reference/fileops.md
+++ b/docs/reference/fileops.md
@@ -25,10 +25,10 @@ Set via `feature.fs.mode`:
 
 | Mode | Reads | Writes | Notes |
 |---|---|---|---|
-| `local` | local | local | mirrord does nothing — no fs syscalls are intercepted. Equivalent to `feature.fs: false`. |
+| `local` | local | local | mirrord does nothing; no fs syscalls are intercepted. Equivalent to `feature.fs: false`. |
 | `localwithoverrides` | local (except overrides) | local (except overrides) | Default behavior is local; only paths matching `read_only`, `read_write`, or the [pre-defined remote-by-default list](#default-overrides) go to the remote pod. |
-| `read` *(default)* | remote (except overrides) | local | Reads come from the pod; writes stay local. Safest mode — you can't accidentally modify the cluster. |
-| `write` | remote (except overrides) | remote | Reads and writes both go to the pod. Use with care — writes hit the real remote filesystem. |
+| `read` *(default)* | remote (except overrides) | local | Reads come from the pod; writes stay local. Safest mode; you can't accidentally modify the cluster. |
+| `write` | remote (except overrides) | remote | Reads and writes both go to the pod. Use with care; writes hit the real remote filesystem. |
 
 Shorthand: `"fs": "read"`, `"fs": false` (= `local`), `"fs": true` (= `write`).
 
@@ -58,20 +58,20 @@ Shorthand: `"fs": "read"`, `"fs": false` (= `local`), `"fs": true` (= `write`).
 | `read_write` | Regex patterns. Matching paths always go to the remote pod, read and write. |
 | `read_only` | Regex patterns. Matching paths read from the remote pod; writes go local. |
 | `local` | Regex patterns. Matching paths always stay local, regardless of mode. |
-| `not_found` | Regex patterns. Matching paths return `ENOENT` to the application — useful for hiding files that exist locally but would confuse a cluster-context process (e.g. `~/.aws/credentials`). |
+| `not_found` | Regex patterns. Matching paths return `ENOENT` to the application. Useful for hiding files that exist locally but would confuse a cluster-context process (e.g. `~/.aws/credentials`). |
 | `mapping` | Regex → replacement applied to the path **before** routing. Capture groups are supported (`$1`, `${name}`). Useful when local paths don't match remote paths (common on Windows). |
 | `readonly_file_buffer` | Buffer size in bytes for read-only remote files. Default `128000` (128 kB). Set `0` to disable buffering. Hard limit 15 MB. |
 
-All pattern lists are case-insensitive. If a path matches more than one list, the **first** match wins — order across lists is not guaranteed, so don't put the same path in two lists.
+All pattern lists are case-insensitive. If a path matches more than one list, the **first** match wins; order across lists is not guaranteed, so don't put the same path in two lists.
 
 ## Resolution order
 
 For each fs syscall the layer intercepts, mirrord resolves the routing in this order:
 
-1. **`mapping`** — if the path matches a `mapping` entry, replace it before proceeding.
-2. **User pattern lists** — `read_write`, `read_only`, `local`, `not_found`. First match wins.
-3. **[Default overrides](#default-overrides)** — built-in lists that override the mode for specific paths regardless of user config.
-4. **`mode`** — the fallback routing for paths nothing else matched.
+1. **`mapping`**: if the path matches a `mapping` entry, replace it before proceeding.
+2. **User pattern lists**: `read_write`, `read_only`, `local`, `not_found`. First match wins.
+3. **[Default overrides](#default-overrides)**: built-in lists that override the mode for specific paths regardless of user config.
+4. **`mode`**: the fallback routing for paths nothing else matched.
 
 ## Default overrides
 
@@ -83,7 +83,7 @@ mirrord ships built-in pattern lists that override the active mode. These exist 
 | Remote-by-default (when mode is `localwithoverrides`) | Read remotely even though mode says local | [`unix`](https://github.com/metalbear-co/mirrord/blob/latest/mirrord/layer-lib/src/file/unix/read_remote_by_default.rs) · [`windows`](https://github.com/metalbear-co/mirrord/blob/latest/mirrord/layer-lib/src/file/windows/read_remote_by_default.rs) |
 | Not-found-by-default (under `$HOME`, all modes except `local`) | Always `ENOENT` | [`unix`](https://github.com/metalbear-co/mirrord/blob/latest/mirrord/layer-lib/src/file/unix/not_found_by_default.rs) · [`windows`](https://github.com/metalbear-co/mirrord/blob/latest/mirrord/layer-lib/src/file/windows/not_found_by_default.rs) |
 
-To override a default — for example, to read `/etc/` remotely even though it's local-by-default — add it to the appropriate user list: `"read_only": ["^/etc/.+"]`.
+To override a default (for example, to read `/etc/` remotely even though it's local-by-default), add it to the appropriate user list: `"read_only": ["^/etc/.+"]`.
 
 ## Intercepted syscalls
 
@@ -135,7 +135,7 @@ When a hooked syscall receives a relative path with no anchoring directory fd, t
 └──────────────────────────┘
 ```
 
-The agent uses the container runtime's API (containerd, docker, CRI-O) to get the PID of the target container. It then accesses the container's filesystem through `/proc/<container-pid>/root`, which gives it the view of the mount namespace the container sees — including ConfigMap/Secret mounts and persistent volumes.
+The agent uses the container runtime's API (containerd, docker, CRI-O) to get the PID of the target container. It then accesses the container's filesystem through `/proc/<container-pid>/root`, which gives it the view of the mount namespace the container sees, including ConfigMap/Secret mounts and persistent volumes.
 
 The agent does not exec inside the container; it reads/writes from the agent pod with the kernel doing the namespace translation. This is why the agent needs `CAP_SYS_ADMIN` (joining mount/PID namespaces).
 
@@ -145,6 +145,6 @@ mirrord does not currently intercept `inotify`/`fanotify` syscalls. Applications
 
 ## Related
 
-- [`feature.fs` config reference](https://metalbear.com/mirrord/docs/config#feature.fs) — full schema
-- [Architecture](architecture.md) — layer / intproxy / agent
-- [Using mirrord → File Operations](../using-mirrord/file-operations.md) — quick how-to
+- [`feature.fs` config reference](https://metalbear.com/mirrord/docs/config#feature.fs): full schema
+- [Architecture](architecture.md): layer / intproxy / agent
+- [Using mirrord → File Operations](../using-mirrord/file-operations.md): quick how-to

--- a/docs/reference/fileops.md
+++ b/docs/reference/fileops.md
@@ -13,7 +13,7 @@ toc: true
 tags: ["open source", "team", "enterprise"]
 ---
 
-mirrord intercepts file syscalls in the local process and routes them to the target pod, so the local app sees the same `/etc/`, `/var/`, mounted ConfigMaps, mounted Secrets, and volume contents the deployed pod does. This page covers what gets intercepted, the four fs modes, the override/pattern system, and the agent-side mechanism.
+mirrord intercepts file syscalls in the local process and routes them to the target pod, so the local app sees the same `/etc/`, `/var/`, mounted ConfigMaps, mounted Secrets, and volume contents the deployed pod does.
 
 For the how-to version, see [Using mirrord → File Operations](../using-mirrord/file-operations.md).
 
@@ -26,13 +26,13 @@ Set via `feature.fs.mode`:
 | Mode | Reads | Writes | Notes |
 |---|---|---|---|
 | `local` | local | local | mirrord does nothing; no fs syscalls are intercepted. Equivalent to `feature.fs: false`. |
-| `localwithoverrides` | local (except overrides) | local (except overrides) | Default behavior is local; only paths matching `read_only`, `read_write`, or the [pre-defined remote-by-default list](#default-overrides) go to the remote pod. |
+| `localwithoverrides` | local (except overrides) | local (except overrides) | Default is local; paths matching `read_only`, `read_write`, or the [pre-defined remote-by-default list](#default-overrides) go to the remote pod. |
 | `read` *(default)* | remote (except overrides) | local | Reads come from the pod; writes stay local. Safest mode; you can't accidentally modify the cluster. |
 | `write` | remote (except overrides) | remote | Reads and writes both go to the pod. Use with care; writes hit the real remote filesystem. |
 
 Shorthand: `"fs": "read"`, `"fs": false` (= `local`), `"fs": true` (= `write`).
 
-## Configuration surface
+## Configuration
 
 ```json
 {
@@ -58,20 +58,13 @@ Shorthand: `"fs": "read"`, `"fs": false` (= `local`), `"fs": true` (= `write`).
 | `read_write` | Regex patterns. Matching paths always go to the remote pod, read and write. |
 | `read_only` | Regex patterns. Matching paths read from the remote pod; writes go local. |
 | `local` | Regex patterns. Matching paths always stay local, regardless of mode. |
-| `not_found` | Regex patterns. Matching paths return `ENOENT` to the application. Useful for hiding files that exist locally but would confuse a cluster-context process (e.g. `~/.aws/credentials`). |
-| `mapping` | Regex → replacement applied to the path **before** routing. Capture groups are supported (`$1`, `${name}`). Useful when local paths don't match remote paths (common on Windows). |
+| `not_found` | Regex patterns. Matching paths return `ENOENT` to the application. Useful for hiding local files (`~/.aws/credentials`, `~/.config/gcloud`) that would confuse a cluster-context process. |
+| `mapping` | Regex → replacement applied to the path **before** routing. Capture groups (`$1`, `${name}`) supported. Useful when local paths don't match remote paths (common on Windows). |
 | `readonly_file_buffer` | Buffer size in bytes for read-only remote files. Default `128000` (128 kB). Set `0` to disable buffering. Hard limit 15 MB. |
 
 All pattern lists are case-insensitive. If a path matches more than one list, the **first** match wins; order across lists is not guaranteed, so don't put the same path in two lists.
 
-## Resolution order
-
-For each fs syscall the layer intercepts, mirrord resolves the routing in this order:
-
-1. **`mapping`**: if the path matches a `mapping` entry, replace it before proceeding.
-2. **User pattern lists**: `read_write`, `read_only`, `local`, `not_found`. First match wins.
-3. **[Default overrides](#default-overrides)**: built-in lists that override the mode for specific paths regardless of user config.
-4. **`mode`**: the fallback routing for paths nothing else matched.
+User patterns are checked first, then the [default overrides](#default-overrides), then the active `mode` as the fallback.
 
 ## Default overrides
 
@@ -83,68 +76,13 @@ mirrord ships built-in pattern lists that override the active mode. These exist 
 | Remote-by-default (when mode is `localwithoverrides`) | Read remotely even though mode says local | [`unix`](https://github.com/metalbear-co/mirrord/blob/latest/mirrord/layer-lib/src/file/unix/read_remote_by_default.rs) · [`windows`](https://github.com/metalbear-co/mirrord/blob/latest/mirrord/layer-lib/src/file/windows/read_remote_by_default.rs) |
 | Not-found-by-default (under `$HOME`, all modes except `local`) | Always `ENOENT` | [`unix`](https://github.com/metalbear-co/mirrord/blob/latest/mirrord/layer-lib/src/file/unix/not_found_by_default.rs) · [`windows`](https://github.com/metalbear-co/mirrord/blob/latest/mirrord/layer-lib/src/file/windows/not_found_by_default.rs) |
 
-To override a default (for example, to read `/etc/` remotely even though it's local-by-default), add it to the appropriate user list: `"read_only": ["^/etc/.+"]`.
+To override a default (for example, to read `/etc/` remotely even though it's local-by-default), add the path to the appropriate user list: `"read_only": ["^/etc/.+"]`.
 
-## Intercepted syscalls
-
-mirrord hooks the following libc functions on Linux/macOS. The layer intercepts each call, decides local vs. remote based on the [resolution order](#resolution-order), and either bypasses to the original libc function or sends a request to the agent.
-
-| Category | Hooked |
-|---|---|
-| Open | `open`, `open64`, `openat`, `opendir`, `dirfd` |
-| Read | `read`, `readv`, `pread`, `preadv`, `readlink`, `readdir`, `readdir64`, `readdir_r`, `readdir64_r` |
-| Write | `write`, `pwrite` |
-| Position | `lseek` |
-| Metadata | `access`, `stat`, `lstat`, `statx`, `statfs`, `statvfs`, `fstat`, `fstatat`, `fstatfs`, `fchmod`, `fchown`, `fsync` |
-| Directory | `mkdir`, `rmdir` |
-| Path | `rename`, `unlink`, `unlinkat` |
-
-On macOS the layer also hooks the `_NOCANCEL` and `$INODE64` variants where applicable. The full, current list lives in [`mirrord/layer/src/file/hooks.rs`](https://github.com/metalbear-co/mirrord/blob/latest/mirrord/layer/src/file/hooks.rs).
-
-Windows has its own equivalent hook set in `mirrord-layer-win`.
-
-### Relative path behavior
-
-When a hooked syscall receives a relative path with no anchoring directory fd, the call is **bypassed to libc** (i.e. resolved locally). This avoids ambiguity, since the layer can't know the remote pod's working directory.
-
-`openat` with a valid `dirfd` returned by a previous remote `open` follows the remote directory; with `AT_FDCWD` it behaves like `open`.
-
-### File descriptor disambiguation
-
-`read`, `write`, `lseek`, `stat`, etc. take an fd. The layer maintains a map of fds that belong to remote-opened files. If the fd is a remote one, the call is sent to the agent; otherwise it's bypassed to libc. This means closing and reopening a file with the same path can flip its routing if config or mode changed in between.
-
-## How the agent reads files
-
-```
-┌──────────────────────────┐
-│ Local process            │
-│ ┌──────────────────────┐ │
-│ │   mirrord-layer      │ │  Hooks open/read/write/...
-│ └──────────┬───────────┘ │  Sends FileRequest to intproxy.
-└────────────┼─────────────┘
-             │ FileRequest::Open / Read / Write / ...
-┌────────────▼─────────────┐
-│ mirrord-intproxy         │
-└────────────┬─────────────┘
-             │
-┌────────────▼─────────────┐
-│ mirrord-agent            │  Resolves the target container's
-│   (target netns + mntns) │  rootfs via `/proc/<pid>/root`
-│                          │  and performs the operation
-│                          │  against that path.
-└──────────────────────────┘
-```
-
-The agent uses the container runtime's API (containerd, docker, CRI-O) to get the PID of the target container. It then accesses the container's filesystem through `/proc/<container-pid>/root`, which gives it the view of the mount namespace the container sees, including ConfigMap/Secret mounts and persistent volumes.
-
-The agent does not exec inside the container; it reads/writes from the agent pod with the kernel doing the namespace translation. This is why the agent needs `CAP_SYS_ADMIN` (joining mount/PID namespaces).
-
-### inotify and file watches
+## inotify and file watches
 
 mirrord does not currently intercept `inotify`/`fanotify` syscalls. Applications watching ConfigMap/Secret mounts for changes won't see remote modifications. Workaround: poll the file's mtime via `stat`.
 
 ## Related
 
 - [`feature.fs` config reference](https://metalbear.com/mirrord/docs/config#feature.fs): full schema
-- [Architecture](architecture.md): layer / intproxy / agent
 - [Using mirrord → File Operations](../using-mirrord/file-operations.md): quick how-to

--- a/docs/reference/targets.md
+++ b/docs/reference/targets.md
@@ -16,93 +16,143 @@ tags:
 description: Possible targets for mirrord and how to set them
 ---
 
-## Overview
+A **target** is the Kubernetes resource whose context the local process will impersonate — its network namespace (for incoming/outgoing traffic and DNS), its filesystem (for fs operations), and its environment variables. When a target is specified, the [mirrord-agent](architecture.md#mirrord-agent) runs on the same node as the target pod and joins its namespaces.
 
-You can specify a target on your cluster for mirrord, giving your local application access to the remote target's network environment, file system and environment variables, according to the [configuration](https://metalbear.com/mirrord/docs/config). When a target is specified, a [mirrord-agent](architecture.md#mirrord-agent) pod will be created on the same node as the target pod. The several kinds of supported targets are detailed below. There are also multiple ways to specify a target for mirrord: you can do it in a configuration file, in an IDE dialog, or in the CLI with an argument or an environment variable.
+This page covers what kinds of resources are valid targets, the resource path syntax, how the agent maps workload kinds to actual pods, and how to specify a target across the different mirrord interfaces.
 
-## Possible targets
+For the targetless mode, see [Targetless](../using-mirrord/targetless.md). For the `copy_target` feature, see [Copy Target](../using-mirrord/copy-target.md).
 
-mirrord OSS supports the following Kubernetes objects as targets:
+## Supported target kinds
 
-* Pods
-* Deployments
-* Argo Rollouts
+| Kind | OSS | Teams | Notes |
+|---|---|---|---|
+| `pod` | ✅ | ✅ | The leaf resource. All other kinds resolve to pods. |
+| `deployment` | ✅ | ✅ | In OSS: random replica. In Teams: all replicas. |
+| `rollout` | ✅ | ✅ | Argo Rollouts. Same replica behavior as deployment. |
+| `statefulset` | — | ✅ | Same replica behavior as deployment. |
+| `replicaset` | — | ✅ | Same replica behavior as deployment. |
+| `service` | — | ✅ | Resolved to backing pods via the Service's selector. |
+| `job` | — | ✅ | Requires [`copy_target`](../using-mirrord/copy-target.md). |
+| `cronjob` | — | ✅ | Requires [`copy_target`](../using-mirrord/copy-target.md). |
+| `targetless` | ✅ | ✅ | No impersonation. See [Targetless](../using-mirrord/targetless.md). |
 
-In mirrord OSS, mirrord will always target a random pod when a workload with multiple pods is used as the remote target.
+### Replica handling
 
-mirrord for Teams adds support for the following workloads:
+When a workload has multiple replicas:
 
-* Jobs
-* CronJobs
-* StatefulSets
-* ReplicaSets
-* Services
+- **OSS** picks one random pod replica for the duration of the session.
+- **Teams** binds to all replicas — incoming traffic from any replica can match your filter, and the agent runs alongside one of them but knows about the rest. This is what enables sharing.
 
-In mirrord for Teams, mirrord will always target all pods when a workload with multiple pods is used as the remote target.
+### Container selection
 
-When targeting a Service, mirrord resolves the Service to its backing pods via the Service's selector. Jobs and CronJobs require [`copy_target`](../using-mirrord/copy-target.md) to be enabled.
+If you don't name a container, mirrord picks the **first container in the pod spec**, skipping containers that look like sidecars/service-mesh proxies (Istio, Linkerd, etc.).
 
-Both in mirrord OSS and mirrord for Teams, if you don't name any specific container to be targeted, mirrord will pick the first container from the pod spec. Some containers, like service mesh proxies, will be automatically ignored.
+To pin a specific container, append `/container/<name>` to the target path.
 
-You can specify a target namespace if the target should be found in that namespace instead of the namespace that is currently used by `kubectl`. See the different interfaces below for possible ways of specifying the target and its namespace.
+## Resource path syntax
+
+```
+<kind>/<name>[/container/<container-name>]
+```
+
+Examples:
+
+```
+pod/api-server-6f9b8c7d-x2mzq
+pod/api-server-6f9b8c7d-x2mzq/container/main
+deployment/api
+deploy/api                                  # short form
+rollout/api/container/main
+statefulset/postgres-primary
+service/checkout
+job/nightly-export                          # requires copy_target
+cronjob/billing-rollup/container/runner     # requires copy_target
+targetless
+```
+
+All resource kinds accept both their long and Kubernetes-short forms (`deployment`/`deploy`, `statefulset`/`sts`, etc.) consistent with `kubectl`.
 
 ## Specifying a target
 
-There are multiple ways to specify a target. In all the possible interfaces for specifying a target, the basic format is `<resource-type>/<resource-name>` optionally followed by `/container/<container-name>`. So for specifying a target without specifying a container you can pass
+There are four ways to specify a target. **Precedence**, highest to lowest:
 
+1. CLI argument (`-t`, `-n`)
+2. Environment variable (`MIRRORD_IMPERSONATED_TARGET`, `MIRRORD_TARGET_NAMESPACE`)
+3. Configuration file (`target.path`, `target.namespace`)
+4. IDE dialog prompt (only if none of the above are set)
+
+### Configuration file
+
+Short form:
+
+```json
+{ "target": "pod/lolz/container/main" }
 ```
-deploy/<YOUR-DEPLOYMENT-NAME>
-```
 
-e.g. `deploy/lolz`,
-
-or
-
-```
-pod/<YOUR-POD-NAME>
-```
-
-e.g. `pod/lolz-64698df9b7-6plq8`,
-
-And for also specifying a container, you just add `/container/<CONTAINER-NAME>` at the end, e.g. `pod/lolz-64698df9b7-6plq8/container/main-container`.
-
-### Using a [configuration file](https://metalbear.com/mirrord/docs/config)
-
-The target path from the last section is set under the [`target.path`](https://metalbear.com/mirrord/docs/config#target.path) field. The target's namespace can be set under [`target.namespace`](https://metalbear.com/mirrord/docs/config#target.namespace). By default, the namespace currently specified in the local `kubeconfig` is used.
+Full form (when you need a namespace):
 
 ```json
 {
   "target": {
-    "path": "pod/lolz-64698df9b7-6plq8/container/main-container",
+    "path": "pod/lolz/container/main",
     "namespace": "lolzspace"
   }
 }
 ```
 
-### Using an IDE's dialog
-
-If you are running one of mirrord's IDE extensions and you didn't specify a target via a configuration file, a dialog will pop up for you to pick a target. If you want to choose a target from a different namespace you can set a target namespace in the [configuration file](targets.md#using-a-configuration-file), and the dialog will then contain targets in that namespace. Choose the `No Target ("targetless")` option in the dialog in order to run without a target.
-
-### Using a command line argument
-
-If you are running mirrord from the command line, you can specify the target via `-t` and its namespace via `-n`, e.g. `mirrord exec -t deploy/lolz -n lolzspace my-app`. Values specified by command line arguments will be used even if other values are set in a configuration file or in environment variables.
-
-### Using an environment variable
-
-You can set the target using the environment variable `MIRRORD_IMPERSONATED_TARGET` and the target's namespace using the environment variable `MIRRORD_TARGET_NAMESPACE`. Values specified by environment variables will be used even if other values are set in a configuration file.
-
-## Running without a target
-
-When no target is specified, mirrord will start a _targetless_ agent. That can be useful when you want to connect to services from within the cluster, but you don't have any target that you want to "impersonate" - like when running an external utility or a new microservice. When running targetless, mirrord will forward any connections initiated by your application to be sent out of the cluster, but it will not mirror or steal incoming traffic, as a targetless agent is not connected to any Kubernetes service and does not expose any ports. This means that if your application binds a port and listens on it, that will all happen locally, on your machine. So if you're using a management program that exposes a web interface, you can have it listen for connections on `localhost`, and connect to remote services in the cluster.
-
-If you're using a mirrord configuration file and want to run targetless, you can either leave the `target` key out completely or specify it explicitly. Note that if you want to skip the target dialog in the IDE plugins, you have to specify it explicitly. You can do it with the following configuration:
+Targetless with a namespace (for remote networking from a specific namespace):
 
 ```json
 {
-  "target": "targetless"
+  "target": {
+    "path": "targetless",
+    "namespace": "bear-namespace"
+  }
 }
 ```
 
-In your IDE you can pick the `No Target ("targetless")` option in the target selection dialog (or just not make a selection). Moreover, you should make sure [the environment variable used to specify a target](targets.md#using-an-environment-variable) isn't set (or is set to an empty value).
+The path field maps to [`target.path`](https://metalbear.com/mirrord/docs/config#target.path); the namespace field maps to [`target.namespace`](https://metalbear.com/mirrord/docs/config#target.namespace). When omitted, the namespace defaults to the one in your current `kubectl` context.
 
-> **Note:** In order to set the namespace the agent is going to be created in, set the agent namespace, not the target namespace. That value can be set via the [`agent.namespace` configuration file field](https://metalbear.com/mirrord/docs/config#agent.namespace), the `-a` CLI argument, or the `MIRRORD_AGENT_NAMESPACE` environment variable.
+### CLI
+
+```bash
+mirrord exec -t deploy/api -n production -- my-app
+```
+
+### Environment variables
+
+```bash
+export MIRRORD_IMPERSONATED_TARGET=deploy/api
+export MIRRORD_TARGET_NAMESPACE=production
+mirrord exec -- my-app
+```
+
+### IDE dialog
+
+If none of the above is set, the VS Code and JetBrains extensions show a target picker. To skip the dialog and run targetless, set the config explicitly to `"target": "targetless"` — leaving `target` unset triggers the dialog.
+
+## Namespaces
+
+| What | Set via | Default |
+|---|---|---|
+| Target namespace (where the target lives) | `target.namespace`, `-n`, `MIRRORD_TARGET_NAMESPACE` | The current `kubectl` context namespace |
+| Agent namespace (where the agent pod runs) | [`agent.namespace`](https://metalbear.com/mirrord/docs/config#agent.namespace), `-a`, `MIRRORD_AGENT_NAMESPACE` | The target's namespace |
+
+These are independent. You can target a pod in `app-prod` while running the agent in `mirrord-agents` if your cluster RBAC is set up that way.
+
+## What happens when you specify a target
+
+1. The CLI resolves the resource via the Kubernetes API and chooses a pod (random for OSS workloads, all for Teams).
+2. The agent is scheduled on the same node as the chosen pod (so it can join that pod's namespaces — namespace joining is a node-local operation).
+3. The agent joins the target's network namespace (`CAP_SYS_ADMIN`), gaining the same view of cluster networking the pod has.
+4. The agent reads the target container's PID from the runtime, so it can access the container's filesystem via `/proc/<pid>/root` and its environment via `/proc/<pid>/environ`.
+5. The session's lifetime is tied to the agent pod. When the session ends (CLI exits, IDE stops, idle timeout), the agent is removed.
+
+See [Architecture](architecture.md) for the full session flow.
+
+## Related
+
+- [`target` config reference](https://metalbear.com/mirrord/docs/config#target) — full schema
+- [Targetless](../using-mirrord/targetless.md) — running without a target
+- [Copy Target](../using-mirrord/copy-target.md) — creating a copy of the target pod (required for `job`/`cronjob` targeting)
+- [Sharing the cluster](../sharing-the-cluster/overview.md) — how Teams enables multiple users to target the same workload

--- a/docs/reference/targets.md
+++ b/docs/reference/targets.md
@@ -16,7 +16,7 @@ tags:
 description: Possible targets for mirrord and how to set them
 ---
 
-A **target** is the Kubernetes resource whose context the local process will impersonate — its network namespace (for incoming/outgoing traffic and DNS), its filesystem (for fs operations), and its environment variables. When a target is specified, the [mirrord-agent](architecture.md#mirrord-agent) runs on the same node as the target pod and joins its namespaces.
+A **target** is the Kubernetes resource whose context the local process will impersonate: its network namespace (for incoming/outgoing traffic and DNS), its filesystem (for fs operations), and its environment variables. When a target is specified, the [mirrord-agent](architecture.md#mirrord-agent) runs on the same node as the target pod and joins its namespaces.
 
 This page covers what kinds of resources are valid targets, the resource path syntax, how the agent maps workload kinds to actual pods, and how to specify a target across the different mirrord interfaces.
 
@@ -29,11 +29,11 @@ For the targetless mode, see [Targetless](../using-mirrord/targetless.md). For t
 | `pod` | ✅ | ✅ | The leaf resource. All other kinds resolve to pods. |
 | `deployment` | ✅ | ✅ | In OSS: random replica. In Teams: all replicas. |
 | `rollout` | ✅ | ✅ | Argo Rollouts. Same replica behavior as deployment. |
-| `statefulset` | — | ✅ | Same replica behavior as deployment. |
-| `replicaset` | — | ✅ | Same replica behavior as deployment. |
-| `service` | — | ✅ | Resolved to backing pods via the Service's selector. |
-| `job` | — | ✅ | Requires [`copy_target`](../using-mirrord/copy-target.md). |
-| `cronjob` | — | ✅ | Requires [`copy_target`](../using-mirrord/copy-target.md). |
+| `statefulset` | none | ✅ | Same replica behavior as deployment. |
+| `replicaset` | none | ✅ | Same replica behavior as deployment. |
+| `service` | none | ✅ | Resolved to backing pods via the Service's selector. |
+| `job` | none | ✅ | Requires [`copy_target`](../using-mirrord/copy-target.md). |
+| `cronjob` | none | ✅ | Requires [`copy_target`](../using-mirrord/copy-target.md). |
 | `targetless` | ✅ | ✅ | No impersonation. See [Targetless](../using-mirrord/targetless.md). |
 
 ### Replica handling
@@ -41,7 +41,7 @@ For the targetless mode, see [Targetless](../using-mirrord/targetless.md). For t
 When a workload has multiple replicas:
 
 - **OSS** picks one random pod replica for the duration of the session.
-- **Teams** binds to all replicas — incoming traffic from any replica can match your filter, and the agent runs alongside one of them but knows about the rest. This is what enables sharing.
+- **Teams** binds to all replicas. Incoming traffic from any replica can match your filter, and the agent runs alongside one of them but knows about the rest. This is what enables sharing.
 
 ### Container selection
 
@@ -129,7 +129,7 @@ mirrord exec -- my-app
 
 ### IDE dialog
 
-If none of the above is set, the VS Code and JetBrains extensions show a target picker. To skip the dialog and run targetless, set the config explicitly to `"target": "targetless"` — leaving `target` unset triggers the dialog.
+If none of the above is set, the VS Code and JetBrains extensions show a target picker. To skip the dialog and run targetless, set the config explicitly to `"target": "targetless"`. Leaving `target` unset triggers the dialog.
 
 ## Namespaces
 
@@ -143,7 +143,7 @@ These are independent. You can target a pod in `app-prod` while running the agen
 ## What happens when you specify a target
 
 1. The CLI resolves the resource via the Kubernetes API and chooses a pod (random for OSS workloads, all for Teams).
-2. The agent is scheduled on the same node as the chosen pod (so it can join that pod's namespaces — namespace joining is a node-local operation).
+2. The agent is scheduled on the same node as the chosen pod (so it can join that pod's namespaces; namespace joining is a node-local operation).
 3. The agent joins the target's network namespace (`CAP_SYS_ADMIN`), gaining the same view of cluster networking the pod has.
 4. The agent reads the target container's PID from the runtime, so it can access the container's filesystem via `/proc/<pid>/root` and its environment via `/proc/<pid>/environ`.
 5. The session's lifetime is tied to the agent pod. When the session ends (CLI exits, IDE stops, idle timeout), the agent is removed.
@@ -152,7 +152,7 @@ See [Architecture](architecture.md) for the full session flow.
 
 ## Related
 
-- [`target` config reference](https://metalbear.com/mirrord/docs/config#target) — full schema
-- [Targetless](../using-mirrord/targetless.md) — running without a target
-- [Copy Target](../using-mirrord/copy-target.md) — creating a copy of the target pod (required for `job`/`cronjob` targeting)
-- [Sharing the cluster](../sharing-the-cluster/overview.md) — how Teams enables multiple users to target the same workload
+- [`target` config reference](https://metalbear.com/mirrord/docs/config#target): full schema
+- [Targetless](../using-mirrord/targetless.md): running without a target
+- [Copy Target](../using-mirrord/copy-target.md): creating a copy of the target pod (required for `job`/`cronjob` targeting)
+- [Sharing the cluster](../sharing-the-cluster/overview.md): how Teams enables multiple users to target the same workload

--- a/docs/reference/targets.md
+++ b/docs/reference/targets.md
@@ -18,8 +18,6 @@ description: Possible targets for mirrord and how to set them
 
 A **target** is the Kubernetes resource whose context the local process will impersonate: its network namespace (for incoming/outgoing traffic and DNS), its filesystem (for fs operations), and its environment variables. When a target is specified, the [mirrord-agent](architecture.md#mirrord-agent) runs on the same node as the target pod and joins its namespaces.
 
-This page covers what kinds of resources are valid targets, the resource path syntax, how the agent maps workload kinds to actual pods, and how to specify a target across the different mirrord interfaces.
-
 For the targetless mode, see [Targetless](../using-mirrord/targetless.md). For the `copy_target` feature, see [Copy Target](../using-mirrord/copy-target.md).
 
 ## Supported target kinds
@@ -139,16 +137,6 @@ If none of the above is set, the VS Code and JetBrains extensions show a target 
 | Agent namespace (where the agent pod runs) | [`agent.namespace`](https://metalbear.com/mirrord/docs/config#agent.namespace), `-a`, `MIRRORD_AGENT_NAMESPACE` | The target's namespace |
 
 These are independent. You can target a pod in `app-prod` while running the agent in `mirrord-agents` if your cluster RBAC is set up that way.
-
-## What happens when you specify a target
-
-1. The CLI resolves the resource via the Kubernetes API and chooses a pod (random for OSS workloads, all for Teams).
-2. The agent is scheduled on the same node as the chosen pod (so it can join that pod's namespaces; namespace joining is a node-local operation).
-3. The agent joins the target's network namespace (`CAP_SYS_ADMIN`), gaining the same view of cluster networking the pod has.
-4. The agent reads the target container's PID from the runtime, so it can access the container's filesystem via `/proc/<pid>/root` and its environment via `/proc/<pid>/environ`.
-5. The session's lifetime is tied to the agent pod. When the session ends (CLI exits, IDE stops, idle timeout), the agent is removed.
-
-See [Architecture](architecture.md) for the full session flow.
 
 ## Related
 

--- a/docs/reference/traffic.md
+++ b/docs/reference/traffic.md
@@ -16,168 +16,199 @@ tags:
 description: Reference to working with network traffic with mirrord
 ---
 
-## Incoming
+mirrord intercepts the local process's network operations and proxies them through the target pod. This page covers what mirrord does end-to-end for incoming traffic (mirror and steal), outgoing traffic (TCP/UDP/Unix sockets), and DNS resolution — including the configuration surface, defaults, and edge cases worth knowing.
 
-mirrord lets users debug incoming network traffic by mirroring or stealing the traffic sent to the remote pod.
+For the how-to versions, see [Using mirrord → Incoming Traffic](../using-mirrord/incoming-traffic/README.md) and [Outgoing Traffic](../using-mirrord/outgoing-traffic/README.md).
 
-### Mirroring
+## Incoming traffic
 
-mirrord's default configuration is to mirror incoming TCP traffic from the remote pod, i.e. run the local process in the context of cloud environment without disrupting incoming traffic for the remote pod. Any responses by the local process to the mirrored requests are dropped, and so whatever application is running on the remote pod continues to operate normally while the traffic is mirrored to the local process.
+Incoming traffic has three modes, set via `feature.network.incoming.mode`:
 
-Example - `user-service` a simple Kubernetes deployment and service that stores registered users.
+| Mode | Behavior |
+|---|---|
+| `mirror` (default) | The agent sniffs TCP traffic on the target's ports and sends a copy to the local process. The remote pod still receives and responds to every request. Responses from the local process are dropped. |
+| `steal` | The agent intercepts TCP traffic and redirects it to the local process. The remote pod stops receiving stolen requests. The local process is now responsible for responding. |
+| `off` | Incoming traffic is disabled. The local process doesn't receive cluster traffic on any port. |
 
-```bash
-bigbear@metalbear:~/mirrord$ minikube service list
-|-------------|-------------------|--------------|---------------------------|
-|  NAMESPACE  |       NAME        | TARGET PORT  |            URL            |
-|-------------|-------------------|--------------|---------------------------|
-| default     | kubernetes        | No node port |
-| default     | user-service      |           80 | http://192.168.49.2:32000 |
-| kube-system | kube-dns          | No node port |
-|-------------|-------------------|--------------|---------------------------|
+Shorthand: `"incoming": "steal"`, `"incoming": "mirror"`, `"incoming": false` (= `off`), `"incoming": true` (= `steal`).
 
-bigbear@metalbear:~/mirrord-demo$ curl -X POST -H "Content-type: application/json" -d "{\"Name\" : \"Metal\", \"Last\" : \"Bear\"}" http://192.168.49.2:32000/user
-{"Last":"Bear","Name":"Metal"}
+### Steal mode has two sub-modes
 
-bigbear@metalbear:~/mirrord-demo$ curl http://192.168.49.2:31000/index.html
-<html> <head>USERS</head><body><h1> MetalBear Users</h1><p>[{"Last":"Bear","Name":"Metal"}]</p></body></html>
+When `incoming.mode` is `steal`:
+
+1. **Port stealing** (no HTTP filter set): all TCP traffic on each port the local process listens on is stolen.
+2. **HTTP stealing** (HTTP filter set): the agent sniffs the first bytes of each new connection on the listened ports, and:
+   - If the connection looks like HTTP and the request matches the filter → stolen.
+   - If the connection looks like HTTP but the request does not match → forwarded to the remote pod.
+   - If the connection is not HTTP → forwarded to the remote pod.
+
+HTTP detection is best-effort and has a timeout (`MIRRORD_AGENT_HTTP_DETECTION_TIMEOUT`). If the connection sends no data before the timeout, the agent treats it as non-HTTP.
+
+### HTTP filter types
+
+Set under `feature.network.incoming.http_filter`. Only active when `incoming.mode` is `steal`.
+
+| Filter | Matches |
+|---|---|
+| `header_filter` | Regex matched against each header as `Header-Name: Header-Value`. Case-insensitive. |
+| `path_filter` | Regex matched against the request path, both with and without the query string. |
+| `method_filter` | The HTTP method. Case-insensitive. Supports standard and custom methods. |
+| `body_filter` | Currently only JSON: `{ "body": "json", "query": "<JSONPath>", "matches": "<regex>" }`. Returns true if any node selected by the JSONPath matches the regex. |
+| `header_filter_jq` | A jq expression evaluated against each `Header-Name: Header-Value`. Matches if the expression returns `true`. |
+| `all_of` / `any_of` | An array of the above as composite filters. `all_of` requires every entry to match; `any_of` requires at least one. |
+| `ports` | When set, the filter applies only to these ports. **When absent, the filter applies to all ports the local process listens on.** |
+
+All regex filters use the [`fancy-regex`](https://docs.rs/fancy-regex/latest/fancy_regex/index.html) crate (supports lookarounds and backreferences).
+
+**Recommended pattern for isolating one developer's session:** match a W3C `baggage` or `tracestate` entry that the caller propagates, e.g. `header_filter: "^baggage: .*mirrord-session=alice.*"`. This works across proxies, service meshes, and tracing-aware clients without requiring custom headers.
+
+**Composite example — POST to a specific endpoint from a specific session:**
+
+```json
+{
+  "http_filter": {
+    "all_of": [
+      { "header": "^baggage: .*mirrord-session=alice.*" },
+      { "path":   "^/api/v1/orders$" },
+      { "method": "POST" }
+    ]
+  }
+}
 ```
 
-```bash
-bigbear@metalbear:~/mirrord$ kubectl get pods
-NAME                                        READY   STATUS    RESTARTS      AGE
-metalbear-bff-deployment-597cb4f957-485t5   1/1     Running   1 (15h ago)   16h
-metalbear-deployment-85c754c75f-6k7mg       1/1     Running   1 (15h ago)   16h
+### Other incoming options
+
+| Field | Default | Behavior |
+|---|---|---|
+| `port_mapping` | `[]` | `[[local, remote]]` pairs. Tells mirrord to mirror/steal remote port X and deliver to local port Y. Useful when local code listens on a different port than the cluster service. |
+| `listen_ports` | `[]` | `[[remote, local-bind]]` pairs. Forces the local in-process listener to bind to a specific port instead of a random fallback. Useful when listening on a privileged port (e.g. remote 80 → local 4480) without `sudo`. Independent of `port_mapping`. |
+| `ignore_ports` | `[]` | Ports to leave local. Common use: skip kubelet health probes when stealing. Mutually exclusive with `ports`. |
+| `ports` | unset | If set, only these ports are mirrored/stolen; others stay local. Mutually exclusive with `ignore_ports`. |
+| `ignore_localhost` | `false` | If `true`, traffic to `127.0.0.1` is treated as local. |
+| `on_concurrent_steal` | `abort` | (Operator only) What to do when another session already has a steal lock on the target: `abort` (fail), `continue` (proceed without stealing), `override` (force-close the existing lock). |
+| `tls_delivery` | unset | (Operator only) How mirrord delivers stolen TLS traffic to the local app. See [steal-https](../using-mirrord/incoming-traffic/steal-https.md). |
+
+### How a steal subscription works
+
+```
+┌──────────────────────────┐
+│ Local process            │
+│   listen(0.0.0.0:8080)   │
+│   ┌──────────────────┐   │
+│   │  mirrord-layer   │   │  Layer detects the listen()
+│   └────────┬─────────┘   │  and tells intproxy.
+└────────────┼─────────────┘
+             │ PortSubscribe
+┌────────────▼─────────────┐
+│ mirrord-intproxy         │
+└────────────┬─────────────┘
+             │ PortSubscribe(8080, filter?)
+┌────────────▼─────────────┐
+│ mirrord-agent            │  Adds an iptables redirection
+│   (target netns)         │  for port 8080 → agent port.
+│                          │  For each new conn: detects
+│                          │  HTTP if a filter is set,
+│                          │  applies the filter, then
+│                          │  forwards stolen traffic up
+│                          │  to the layer.
+└──────────────────────────┘
 ```
 
-To mirror traffic from remote services to the local development environment, run the services locally with mirrord
+The agent installs port redirections inside the target pod's network namespace. They are removed when the session ends. If the agent process is killed uncleanly, the operator (or the cluster's eventual pod restart) cleans them up.
 
-#### Window 1
+## Outgoing traffic
 
-```bash
-bigbear@metalbear:~/mirrord-demo$ ../mirrord/target/debug/mirrord exec -c
---no-outgoing --target pod/metalbear-deployment-85c754c75f-6k7mg python3
-user-service/service.py 
- * Serving Flask app 'service' (lazy loading)
- * Environment: production
-   WARNING: This is a development server. Do not use it in a production deployment.
-   Use a production WSGI server instead.
- * Debug mode: off
- * Running on all addresses (0.0.0.0)
-   WARNING: This is a development server. Do not use it in a production deployment.
- * Running on http://127.0.0.1:33695
- * Running on http://172.16.0.4:33695 (Press CTRL+C to quit)
- 127.0.0.1 - - [08/Sep/2022 15:34:34] "GET /users HTTP/1.1" 200
-// ^ Received mirrored traffic from the remote pod
+Outgoing traffic is forwarded by default for both TCP and UDP. The local process opens what looks like a normal socket; the layer hands it off to intproxy, which has the agent open the actual connection from inside the target pod and tunnels the bytes back.
+
+```json
+{
+  "feature": {
+    "network": {
+      "outgoing": {
+        "tcp": true,
+        "udp": true,
+        "ignore_localhost": false,
+        "filter": {
+          "local": ["tcp://127.0.0.1:5432", ":53"]
+        },
+        "unix_streams": "^/var/run/.+"
+      }
+    }
+  }
+}
 ```
 
-#### Window 2
+| Field | Default | Behavior |
+|---|---|---|
+| `tcp` | `true` | Forward outgoing TCP through the pod. |
+| `udp` | `true` | Forward outgoing UDP through the pod. Only works if the app binds a non-zero port and calls `connect()` before sending. |
+| `ignore_localhost` | `false` | Treat `127.0.0.1` traffic as local. |
+| `filter.remote` | — | Only matching destinations go through the pod; everything else stays local. |
+| `filter.local` | — | Only matching destinations stay local; everything else goes through the pod. (Mutually exclusive with `filter.remote`.) |
+| `unix_streams` | — | Regex (or list of regexes) on Unix socket paths. Matching connections are forwarded to the pod; non-matching stay local. |
 
-```bash
-bigbear@metalbear:~/mirrord-demo$ curl http://192.168.49.2:32000/users
-[{"Last":"Bear","Name":"Metal"}]
-```                                                                                                                                             
+### Outgoing filter syntax
 
-### Stealing
+Each filter entry: `[protocol]://[name|address|subnet/mask]:[port]`. All parts optional.
 
-mirrord can steal network traffic, i.e. intercept it and send it to the local process instead of the remote pod. This means that all incoming traffic is only handled by the local process.
+| Entry | Meaning |
+|---|---|
+| `tcp://1.1.1.0/24:1337` | TCP only, that subnet, that port |
+| `1.1.5.0/24` | Both protocols, that subnet, any port |
+| `google.com:7331` | Both protocols, that hostname (resolved), that port |
+| `:53` | Both protocols, any host, port 53 |
 
-Example - running `user-service` with mirrord and `--steal` on:
+### The mirror + outgoing gotcha
 
+If `incoming.mode` is `mirror` (default) **and** outgoing is enabled (default) **and** your handler does writes (e.g. a DB insert), every mirrored request causes **two** writes — one from the remote pod, one from your local copy.
 
-#### Window 1
+Three ways to avoid this:
 
-```bash
-bigbear@metalbear:~/mirrord-demo$ ../mirrord/target/debug/mirrord exec -c 
---steal --target pod/metalbear-deployment-85c754c75f-6k7mg
-python3 user-service/service.py 
- * Serving Flask app 'service' (lazy loading)
- * Environment: production
-   WARNING: This is a development server. Do not use it in a production deployment.
-   Use a production WSGI server instead.
- * Debug mode: off
- * Running on all addresses (0.0.0.0)
-   WARNING: This is a development server. Do not use it in a production deployment.
- * Running on http://127.0.0.1:35215
- * Running on http://172.16.0.4:35215 (Press CTRL+C to quit) 
- 127.0.0.1 - - [08/Sep/2022 15:48:40] "GET /users HTTP/1.1" 200 -
- 127.0.0.1 - - [08/Sep/2022 15:50:40] "POST /user HTTP/1.1" 200 -
- 127.0.0.1 - - [08/Sep/2022 15:50:55] "GET /users HTTP/1.1" 200 -
- 127.0.0.1 - - [08/Sep/2022 16:57:51] "POST /user HTTP/1.1" 200 -
- 127.0.0.1 - - [08/Sep/2022 16:57:54] "GET /users HTTP/1.1" 200 -
- ^Cbigbear@metalbear:~/mirrord-demo$ 
+1. Switch to `steal` mode — only one process handles each request.
+2. Disable outgoing traffic if the target services are cluster-internal.
+3. Use an outgoing filter to send specific destinations local-only.
+
+## DNS resolution
+
+```json
+{
+  "feature": {
+    "network": {
+      "dns": {
+        "enabled": true,
+        "filter": {
+          "local": ["localhost", ":53"]
+        }
+      }
+    }
+  }
+}
 ```
 
-#### Window 2
+When enabled (default), `getaddrinfo` / `gethostbyname` calls in the local process are forwarded to the agent, which resolves them using the target pod's resolver. This is what makes `my-service.default.svc.cluster.local` work from your laptop.
 
-```bash
-// Before running mirrord with `--steal`
-bigbear@metalbear:~/mirrord-demo$ curl http://192.168.49.2:32000/users
-[{"Last":"Bear","Name":"Metal"}]
+### DNS filter syntax
 
-// After running with mirrord and `--steal` - local process responds
- instead of the remote
-bigbear@metalbear:~/mirrord-demo$ curl http://192.168.49.2:32000/users
-[]
-bigbear@metalbear:~/mirrord-demo$ curl -X POST -H 
-"Content-type: application/json" 
--d "{\"Name\" : \"Mehul\", \"Last\" : \"Arora\"}" http://192.168.49.2:32000/user
+Same format as outgoing, minus the protocol: `[name|address|subnet/mask][:port]`.
 
-{"Last":"Arora","Name":"Mehul"}
-bigbear@metalbear:~/mirrord-demo$ curl http://192.168.49.2:32000/users
-[{"Last":"Arora","Name":"Mehul"}]
-bigbear@metalbear:~/mirrord-demo$ curl -X POST -H 
-"Content-type: application/json" 
--d "{\"Name\" : \"Alex\", \"Last\" : \"C\"}" http://192.168.49.2:32000/user
-{"Last":"C","Name":"Alex"}
-bigbear@metalbear:~/mirrord-demo$ curl http://192.168.49.2:32000/users
-[{"Last":"Arora","Name":"Mehul"},{"Last":"C","Name":"Alex"}]
+| Field | Behavior |
+|---|---|
+| `filter.remote` | Only matching queries go to the pod's resolver; others use the local resolver. |
+| `filter.local` | Only matching queries stay local; others go to the pod's resolver. |
 
-// After sending SIGINT to the local process
-bigbear@metalbear:~/mirrord-demo$ curl http://192.168.49.2:32000/users
-[{"Last":"Bear","Name":"Metal"}]
-```
+### Limitations
 
-**Filtering Incoming Traffic by HTTP Headers**
+- **Only works with `getaddrinfo` / `gethostbyname`.** Frameworks that talk to a DNS server directly on port 53 (some Go DNS clients, some custom resolvers) bypass mirrord entirely. If you see resolution errors with such a framework, enable the `fs` feature with `read_only: ["/etc/resolv.conf"]` so the resolver reads the pod's DNS config from the (remote) file system.
+- DNS filter currently only applies to `getaddrinfo` / `gethostbyname` paths.
 
-mirrord lets you specify a regular expression to filter HTTP requests with. When specified, all the headers of each HTTP request that arrives at the remote target are checked against the regular expression. If any of the headers match, the request will be stolen, otherwise, it will be sent to the remote target. For each `Header-Name`, `Header-Value` pair, your regular expression will be matched against `Header-Name: Header-Value`. You can filter on any header, including the W3C trace propagation headers `baggage` or `tracestate` — for example `^baggage: .*mirrord-session=alice.*` (if you use OpenTelemetry or another tracing library, these headers are often propagated automatically). The regular expression is evaluated with the [fancy\_regex](https://docs.rs/fancy-regex/0.10.0/fancy_regex/index.html) rust crate.
+## IPv6
 
-**Specifying a Filter**
+`feature.network.ipv6` (default `false`). Enable if the local app listens on or connects to IPv6 addresses. Off by default because most clusters are IPv4 and turning it on adds extra socket bookkeeping.
 
-An HTTP filter can be specified in the mirrord configuration file by setting the incoming mode to `steal` and specifying a filter in [`feature.network.incoming.http_filter.header_filter`](https://metalbear.com/mirrord/docs/config#feature.network.incoming.http_filter.header_filter) or [`feature.network.incoming.http_filter.path_filter`](https://metalbear.com/mirrord/docs/config#feature.network.incoming.http_filter.path_filter).
+## Related
 
-**Setting Custom HTTP Ports**
-
-The configuration also allows specifying custom HTTP ports under `feature.network.incoming.http_filter.ports`. By default, ports 80 and 8080 are used as HTTP ports if a filter is specified, which means that the mirrord agent checks each new connection on those ports for HTTP, and if the connection has valid HTTP messages, they are filtered with the header filter.
-
-## Outgoing
-
-mirrord's outgoing traffic feature intercepts outgoing requests from the local process and sends them through the remote pod instead. Responses are then routed back to the local process. A simple use case of this feature is enabling the local process to make an API call to another service in the k8s cluster, for example, a database read/write.
-
-For UDP, outgoing traffic is currently only intercepted and forwarded by mirrord if the application binds a non-0 port and makes a `connect` call on the socket before sending out messages. Outgoing TCP and UDP forwarding are both enabled by default. It can be controlled individually for TCP and UDP or disabled altogether (see `mirrord exec --help`).
-
-> **Note:** If the handling of incoming requests by your app involves outgoing API calls to other services, and mirrord is configured to mirror incoming traffic, then it might be the case that both the remote pod and the local process (which receives mirrored requests) make an outgoing API call to another service for the same incoming request. If that call is a write operation to a database, this could lead e.g. to duplicate lines in the database. You can avoid such an effect by switching from [traffic mirroring](traffic.md#mirroring) to [traffic stealing](traffic.md#stealing) mode. Alternatively, if the service your application makes an API call to is only reachable from within the Kubernetes cluster, you can disable outgoing traffic forwarding, which would make it impossible for your local process to reach that service.
-
-## DNS Resolution
-
-mirrord can resolve DNS queries in the context of the remote pod
-
-Example - calling `getaddrinfo` to see if the query is resolved:
-
-```bash
-Python 3.8.10 (default, Jun 22 2022, 20:18:18) 
-[GCC 9.4.0] on linux
-Type "help", "copyright", "credits" or "license" for more information.
->>> import socket
->>> socket.getaddrinfo('localhost', None)
-2022-09-08T17:37:50.735532Z  INFO mirrord_layer::socket::ops: getaddrinfo -> result Ok(
-    0x00007f5508004760,
-)
-[(<AddressFamily.AF_INET6: 10>, <SocketKind.SOCK_STREAM: 1>, 6, '', ('::7074:e00d:557f:0', 0, 0, 97)), (<AddressFamily.AF_INET6: 10>, <SocketKind.SOCK_DGRAM: 2>, 17, '', ('::', 0, 0, 0)), (<AddressFamily.AF_INET6: 10>, <SocketKind.SOCK_RAW: 3>, 0, '', ('::90bf:f401:0:0', 0, 0, 245652448)), (<AddressFamily.AF_INET: 2>, <SocketKind.SOCK_STREAM: 1>, 6, '', ('127.0.0.1', 0)), (<AddressFamily.AF_INET: 2>, <SocketKind.SOCK_DGRAM: 2>, 17, '', ('127.0.0.1', 0)), (<AddressFamily.AF_INET: 2>, <SocketKind.SOCK_RAW: 3>, 0, '', ('127.0.0.1', 0))]
->>> socket.getaddrinfo('user-service', None)
-2022-09-08T17:38:17.556108Z  INFO mirrord_layer::socket::ops: getaddrinfo -> result Ok(
-    0x00007f5508003610,
-)
-[(<AddressFamily.AF_INET: 2>, <SocketKind.SOCK_STREAM: 1>, 6, '', ('10.106.158.180', 0)), (<AddressFamily.AF_INET: 2>, <SocketKind.SOCK_DGRAM: 2>, 17, '', ('10.106.158.180', 0)), (<AddressFamily.AF_INET: 2>, <SocketKind.SOCK_RAW: 3>, 0, '', ('10.106.158.180', 0))]
->>> 
-```
+- [`feature.network` config reference](https://metalbear.com/mirrord/docs/config#feature.network) — full schema
+- [Architecture](architecture.md) — layer / intproxy / agent
+- [Using mirrord → Incoming Traffic](../using-mirrord/incoming-traffic/README.md)
+- [Using mirrord → Outgoing Traffic](../using-mirrord/outgoing-traffic/README.md)
+- [Steal HTTPS](../using-mirrord/incoming-traffic/steal-https.md) — for `tls_delivery`

--- a/docs/reference/traffic.md
+++ b/docs/reference/traffic.md
@@ -16,7 +16,7 @@ tags:
 description: Reference to working with network traffic with mirrord
 ---
 
-mirrord intercepts the local process's network operations and proxies them through the target pod. This page covers what mirrord does end-to-end for incoming traffic (mirror and steal), outgoing traffic (TCP/UDP/Unix sockets), and DNS resolution, including the configuration surface, defaults, and edge cases worth knowing.
+mirrord intercepts the local process's network operations and proxies them through the target pod. This page covers incoming traffic (mirror and steal), outgoing traffic (TCP/UDP/Unix sockets), and DNS resolution.
 
 For the how-to versions, see [Using mirrord → Incoming Traffic](../using-mirrord/incoming-traffic/README.md) and [Outgoing Traffic](../using-mirrord/outgoing-traffic/README.md).
 
@@ -37,12 +37,9 @@ Shorthand: `"incoming": "steal"`, `"incoming": "mirror"`, `"incoming": false` (=
 When `incoming.mode` is `steal`:
 
 1. **Port stealing** (no HTTP filter set): all TCP traffic on each port the local process listens on is stolen.
-2. **HTTP stealing** (HTTP filter set): the agent sniffs the first bytes of each new connection on the listened ports, and:
-   - If the connection looks like HTTP and the request matches the filter → stolen.
-   - If the connection looks like HTTP but the request does not match → forwarded to the remote pod.
-   - If the connection is not HTTP → forwarded to the remote pod.
+2. **HTTP stealing** (HTTP filter set): the agent sniffs the first bytes of each new connection on the listened ports. HTTP requests that match the filter are stolen; everything else is forwarded to the remote pod.
 
-HTTP detection is best-effort and has a timeout (`MIRRORD_AGENT_HTTP_DETECTION_TIMEOUT`). If the connection sends no data before the timeout, the agent treats it as non-HTTP.
+HTTP detection is best-effort and has a timeout (`MIRRORD_AGENT_HTTP_DETECTION_TIMEOUT`).
 
 ### HTTP filter types
 
@@ -80,7 +77,7 @@ All regex filters use the [`fancy-regex`](https://docs.rs/fancy-regex/latest/fan
 
 | Field | Default | Behavior |
 |---|---|---|
-| `port_mapping` | `[]` | `[[local, remote]]` pairs. Tells mirrord to mirror/steal remote port X and deliver to local port Y. Useful when local code listens on a different port than the cluster service. |
+| `port_mapping` | `[]` | `[[local, remote]]` pairs. Mirror/steal remote port X and deliver to local port Y. Useful when local code listens on a different port than the cluster service. |
 | `listen_ports` | `[]` | `[[remote, local-bind]]` pairs. Forces the local in-process listener to bind to a specific port instead of a random fallback. Useful when listening on a privileged port (e.g. remote 80 → local 4480) without `sudo`. Independent of `port_mapping`. |
 | `ignore_ports` | `[]` | Ports to leave local. Common use: skip kubelet health probes when stealing. Mutually exclusive with `ports`. |
 | `ports` | unset | If set, only these ports are mirrored/stolen; others stay local. Mutually exclusive with `ignore_ports`. |
@@ -88,37 +85,9 @@ All regex filters use the [`fancy-regex`](https://docs.rs/fancy-regex/latest/fan
 | `on_concurrent_steal` | `abort` | (Operator only) What to do when another session already has a steal lock on the target: `abort` (fail), `continue` (proceed without stealing), `override` (force-close the existing lock). |
 | `tls_delivery` | unset | (Operator only) How mirrord delivers stolen TLS traffic to the local app. See [steal-https](../using-mirrord/incoming-traffic/steal-https.md). |
 
-### How a steal subscription works
-
-```
-┌──────────────────────────┐
-│ Local process            │
-│   listen(0.0.0.0:8080)   │
-│   ┌──────────────────┐   │
-│   │  mirrord-layer   │   │  Layer detects the listen()
-│   └────────┬─────────┘   │  and tells intproxy.
-└────────────┼─────────────┘
-             │ PortSubscribe
-┌────────────▼─────────────┐
-│ mirrord-intproxy         │
-└────────────┬─────────────┘
-             │ PortSubscribe(8080, filter?)
-┌────────────▼─────────────┐
-│ mirrord-agent            │  Adds an iptables redirection
-│   (target netns)         │  for port 8080 → agent port.
-│                          │  For each new conn: detects
-│                          │  HTTP if a filter is set,
-│                          │  applies the filter, then
-│                          │  forwards stolen traffic up
-│                          │  to the layer.
-└──────────────────────────┘
-```
-
-The agent installs port redirections inside the target pod's network namespace. They are removed when the session ends. If the agent process is killed uncleanly, the operator (or the cluster's eventual pod restart) cleans them up.
-
 ## Outgoing traffic
 
-Outgoing traffic is forwarded by default for both TCP and UDP. The local process opens what looks like a normal socket; the layer hands it off to intproxy, which has the agent open the actual connection from inside the target pod and tunnels the bytes back.
+Outgoing traffic is forwarded by default for both TCP and UDP. The local process opens what looks like a normal socket; the agent opens the actual connection from inside the target pod and tunnels the bytes back.
 
 ```json
 {
@@ -187,14 +156,7 @@ Three ways to avoid this:
 
 When enabled (default), `getaddrinfo` / `gethostbyname` calls in the local process are forwarded to the agent, which resolves them using the target pod's resolver. This is what makes `my-service.default.svc.cluster.local` work from your laptop.
 
-### DNS filter syntax
-
-Same format as outgoing, minus the protocol: `[name|address|subnet/mask][:port]`.
-
-| Field | Behavior |
-|---|---|
-| `filter.remote` | Only matching queries go to the pod's resolver; others use the local resolver. |
-| `filter.local` | Only matching queries stay local; others go to the pod's resolver. |
+DNS filter syntax is the same as outgoing, minus the protocol: `[name|address|subnet/mask][:port]`. `filter.remote` sends only matching queries to the pod's resolver; `filter.local` keeps only matching queries local.
 
 ### Limitations
 
@@ -208,7 +170,6 @@ Same format as outgoing, minus the protocol: `[name|address|subnet/mask][:port]`
 ## Related
 
 - [`feature.network` config reference](https://metalbear.com/mirrord/docs/config#feature.network): full schema
-- [Architecture](architecture.md): layer / intproxy / agent
 - [Using mirrord → Incoming Traffic](../using-mirrord/incoming-traffic/README.md)
 - [Using mirrord → Outgoing Traffic](../using-mirrord/outgoing-traffic/README.md)
 - [Steal HTTPS](../using-mirrord/incoming-traffic/steal-https.md): for `tls_delivery`

--- a/docs/reference/traffic.md
+++ b/docs/reference/traffic.md
@@ -16,7 +16,7 @@ tags:
 description: Reference to working with network traffic with mirrord
 ---
 
-mirrord intercepts the local process's network operations and proxies them through the target pod. This page covers what mirrord does end-to-end for incoming traffic (mirror and steal), outgoing traffic (TCP/UDP/Unix sockets), and DNS resolution — including the configuration surface, defaults, and edge cases worth knowing.
+mirrord intercepts the local process's network operations and proxies them through the target pod. This page covers what mirrord does end-to-end for incoming traffic (mirror and steal), outgoing traffic (TCP/UDP/Unix sockets), and DNS resolution, including the configuration surface, defaults, and edge cases worth knowing.
 
 For the how-to versions, see [Using mirrord → Incoming Traffic](../using-mirrord/incoming-traffic/README.md) and [Outgoing Traffic](../using-mirrord/outgoing-traffic/README.md).
 
@@ -62,7 +62,7 @@ All regex filters use the [`fancy-regex`](https://docs.rs/fancy-regex/latest/fan
 
 **Recommended pattern for isolating one developer's session:** match a W3C `baggage` or `tracestate` entry that the caller propagates, e.g. `header_filter: "^baggage: .*mirrord-session=alice.*"`. This works across proxies, service meshes, and tracing-aware clients without requiring custom headers.
 
-**Composite example — POST to a specific endpoint from a specific session:**
+**Composite example, POST to a specific endpoint from a specific session:**
 
 ```json
 {
@@ -143,9 +143,9 @@ Outgoing traffic is forwarded by default for both TCP and UDP. The local process
 | `tcp` | `true` | Forward outgoing TCP through the pod. |
 | `udp` | `true` | Forward outgoing UDP through the pod. Only works if the app binds a non-zero port and calls `connect()` before sending. |
 | `ignore_localhost` | `false` | Treat `127.0.0.1` traffic as local. |
-| `filter.remote` | — | Only matching destinations go through the pod; everything else stays local. |
-| `filter.local` | — | Only matching destinations stay local; everything else goes through the pod. (Mutually exclusive with `filter.remote`.) |
-| `unix_streams` | — | Regex (or list of regexes) on Unix socket paths. Matching connections are forwarded to the pod; non-matching stay local. |
+| `filter.remote` | none | Only matching destinations go through the pod; everything else stays local. |
+| `filter.local` | none | Only matching destinations stay local; everything else goes through the pod. (Mutually exclusive with `filter.remote`.) |
+| `unix_streams` | none | Regex (or list of regexes) on Unix socket paths. Matching connections are forwarded to the pod; non-matching stay local. |
 
 ### Outgoing filter syntax
 
@@ -160,11 +160,11 @@ Each filter entry: `[protocol]://[name|address|subnet/mask]:[port]`. All parts o
 
 ### The mirror + outgoing gotcha
 
-If `incoming.mode` is `mirror` (default) **and** outgoing is enabled (default) **and** your handler does writes (e.g. a DB insert), every mirrored request causes **two** writes — one from the remote pod, one from your local copy.
+If `incoming.mode` is `mirror` (default) **and** outgoing is enabled (default) **and** your handler does writes (e.g. a DB insert), every mirrored request causes **two** writes: one from the remote pod, one from your local copy.
 
 Three ways to avoid this:
 
-1. Switch to `steal` mode — only one process handles each request.
+1. Switch to `steal` mode: only one process handles each request.
 2. Disable outgoing traffic if the target services are cluster-internal.
 3. Use an outgoing filter to send specific destinations local-only.
 
@@ -207,8 +207,8 @@ Same format as outgoing, minus the protocol: `[name|address|subnet/mask][:port]`
 
 ## Related
 
-- [`feature.network` config reference](https://metalbear.com/mirrord/docs/config#feature.network) — full schema
-- [Architecture](architecture.md) — layer / intproxy / agent
+- [`feature.network` config reference](https://metalbear.com/mirrord/docs/config#feature.network): full schema
+- [Architecture](architecture.md): layer / intproxy / agent
 - [Using mirrord → Incoming Traffic](../using-mirrord/incoming-traffic/README.md)
 - [Using mirrord → Outgoing Traffic](../using-mirrord/outgoing-traffic/README.md)
-- [Steal HTTPS](../using-mirrord/incoming-traffic/steal-https.md) — for `tls_delivery`
+- [Steal HTTPS](../using-mirrord/incoming-traffic/steal-https.md): for `tls_delivery`

--- a/docs/using-mirrord/environment-variables.md
+++ b/docs/using-mirrord/environment-variables.md
@@ -32,7 +32,7 @@ mirrord exec -t pod/my-pod -- env | grep DATABASE_URL
 { "feature": { "env": { "exclude": "SECRET_*;LEGACY_*" } } }
 ```
 
-(`include` and `exclude` are mutually exclusive — pick one.)
+(`include` and `exclude` are mutually exclusive; pick one.)
 
 **Override a value locally**
 
@@ -56,7 +56,7 @@ This is the right fix when something like `AWS_PROFILE` from your shell makes th
 
 ## Gotchas
 
-- mirrord always strips toolchain variables (`PATH`, `HOME`, `JAVA_HOME`, `GOPATH`, `PYTHONPATH`, `CLASSPATH`, etc.) so your local interpreter doesn't break. You can't get these from the remote pod — they're considered local. See the [reference](../reference/env.md#always-excluded-variables) for the full list.
-- Variables set with `os.setenv()` (or equivalent) inside the running pod **won't appear** — mirrord reads `/proc/<pid>/environ`, which is fixed at process start.
+- mirrord always strips toolchain variables (`PATH`, `HOME`, `JAVA_HOME`, `GOPATH`, `PYTHONPATH`, `CLASSPATH`, etc.) so your local interpreter doesn't break. You can't get these from the remote pod; they're considered local. See the [reference](../reference/env.md#always-excluded-variables) for the full list.
+- Variables set with `os.setenv()` (or equivalent) inside the running pod **won't appear**: mirrord reads `/proc/<pid>/environ`, which is fixed at process start.
 
 For mechanism, full schema, post-fetch transformation order, and the complete excluded list, see the [environment variables reference](../reference/env.md).

--- a/docs/using-mirrord/environment-variables.md
+++ b/docs/using-mirrord/environment-variables.md
@@ -6,57 +6,117 @@ toc: true
 tags: ["open source", "team", "enterprise"]
 ---
 
-By default, mirrord imports the target pod's environment variables into your local process. Use this when your local code needs the same database URLs, API keys, or service discovery values as the cluster.
+By default, mirrord imports all environment variables from the remote pod into your local process. This means your local code automatically gets the same database URLs, API keys, feature flags, and service discovery values as the deployed application, without any manual setup.
 
-## Quickstart
+Local environment variables that aren't present in the remote pod are preserved. When a variable exists in both, the remote value wins.
 
-No config needed. Running `mirrord exec -t pod/my-pod -- node server.js` already loads the remote env.
+## Including only specific variables
 
-To verify, print a known variable from the pod:
-
-```bash
-mirrord exec -t pod/my-pod -- env | grep DATABASE_URL
-```
-
-## Common patterns
-
-**Only specific variables**
+If you only need a few remote variables (e.g. a database connection string), use `include` to allowlist them:
 
 ```json
-{ "feature": { "env": { "include": "DATABASE_URL;REDIS_URL" } } }
+{
+  "feature": {
+    "env": {
+      "include": "DATABASE_URL;API_KEY;REDIS_HOST"
+    }
+  }
+}
 ```
 
-**Block certain variables**
+Variables are separated by semicolons. Supports regex patterns: `"include": "DB_.*"`.
+
+## Excluding specific variables
+
+If most remote variables are useful but a few cause problems locally, use `exclude`:
 
 ```json
-{ "feature": { "env": { "exclude": "SECRET_*;LEGACY_*" } } }
+{
+  "feature": {
+    "env": {
+      "exclude": "PATH;HOME;USER;SHELL"
+    }
+  }
+}
 ```
 
-(`include` and `exclude` are mutually exclusive; pick one.)
+`include` and `exclude` are mutually exclusive. Use one or the other.
 
-**Override a value locally**
+## Overriding values
+
+Sometimes you want the remote variable but with a different value. For example, pointing at a local database while keeping everything else remote:
 
 ```json
-{ "feature": { "env": { "override": { "REGION": "us-east-1" } } } }
+{
+  "feature": {
+    "env": {
+      "override": {
+        "DATABASE_URL": "postgres://localhost:5432/mydb",
+        "DEBUG": "true"
+      }
+    }
+  }
+}
 ```
 
-**Merge in a local `.env`**
+Overrides are applied after remote variables are loaded, so they take priority over both remote and local values.
+
+## Loading from a file
+
+You can load overrides from a dotenv-style file:
 
 ```json
-{ "feature": { "env": { "env_file": "./.env.local" } } }
+{
+  "feature": {
+    "env": {
+      "env_file": ".env.local"
+    }
+  }
+}
 ```
 
-**Remove a variable that confuses your tooling**
+## Mapping variable names
+
+If your local code expects a different variable name than what the remote pod uses:
 
 ```json
-{ "feature": { "env": { "unset": ["AWS_PROFILE"] } } }
+{
+  "feature": {
+    "env": {
+      "mapping": {
+        "REMOTE_DB_URL": "DATABASE_URL"
+      }
+    }
+  }
+}
 ```
 
-This is the right fix when something like `AWS_PROFILE` from your shell makes the SDK ignore the remote credentials. `unset` is also the only way to strip variables when running Go (Go can't modify its env after start).
+This maps the remote `REMOTE_DB_URL` value into the local `DATABASE_URL` variable.
+
+## Unsetting variables
+
+To ensure a remote variable is *not* present in your local process at all:
+
+```json
+{
+  "feature": {
+    "env": {
+      "unset": "KUBERNETES_SERVICE_HOST;KUBERNETES_PORT"
+    }
+  }
+}
+```
 
 ## Gotchas
 
 - mirrord always strips toolchain variables (`PATH`, `HOME`, `JAVA_HOME`, `GOPATH`, `PYTHONPATH`, `CLASSPATH`, etc.) so your local interpreter doesn't break. You can't get these from the remote pod; they're considered local. See the [reference](../reference/env.md#always-excluded-variables) for the full list.
 - Variables set with `os.setenv()` (or equivalent) inside the running pod **won't appear**: mirrord reads `/proc/<pid>/environ`, which is fixed at process start.
 
-For mechanism, full schema, post-fetch transformation order, and the complete excluded list, see the [environment variables reference](../reference/env.md).
+## Common scenarios
+
+**"My app connects to the wrong database locally"** The remote `DATABASE_URL` is being imported. Either override it with a local value, or exclude it.
+
+**"I want to test with a feature flag enabled"** Use `override` to set the flag value, regardless of what the remote pod has.
+
+For the full list of environment variable settings, see the [configuration reference](https://metalbear.com/mirrord/docs/config#feature.env).
+For a technical explanation of how environment variables work under the hood, see the [Environment Variables reference](../reference/env.md).

--- a/docs/using-mirrord/environment-variables.md
+++ b/docs/using-mirrord/environment-variables.md
@@ -6,114 +6,57 @@ toc: true
 tags: ["open source", "team", "enterprise"]
 ---
 
-By default, mirrord imports all environment variables from the remote pod into your local process. This means your local code automatically gets the same database URLs, API keys, feature flags, and service discovery values as the deployed application, without any manual setup.
+By default, mirrord imports the target pod's environment variables into your local process. Use this when your local code needs the same database URLs, API keys, or service discovery values as the cluster.
 
-Local environment variables that aren't present in the remote pod are preserved. When a variable exists in both, the remote value wins.
+## Quickstart
 
-## Including only specific variables
+No config needed. Running `mirrord exec -t pod/my-pod -- node server.js` already loads the remote env.
 
-If you only need a few remote variables (e.g. a database connection string), use `include` to allowlist them:
+To verify, print a known variable from the pod:
 
-```json
-{
-  "feature": {
-    "env": {
-      "include": "DATABASE_URL;API_KEY;REDIS_HOST"
-    }
-  }
-}
+```bash
+mirrord exec -t pod/my-pod -- env | grep DATABASE_URL
 ```
 
-Variables are separated by semicolons. Supports regex patterns: `"include": "DB_.*"`.
+## Common patterns
 
-## Excluding specific variables
-
-If most remote variables are useful but a few cause problems locally, use `exclude`:
+**Only specific variables**
 
 ```json
-{
-  "feature": {
-    "env": {
-      "exclude": "PATH;HOME;USER;SHELL"
-    }
-  }
-}
+{ "feature": { "env": { "include": "DATABASE_URL;REDIS_URL" } } }
 ```
 
-`include` and `exclude` are mutually exclusive. Use one or the other.
-
-## Overriding values
-
-Sometimes you want the remote variable but with a different value. For example, pointing at a local database while keeping everything else remote:
+**Block certain variables**
 
 ```json
-{
-  "feature": {
-    "env": {
-      "override": {
-        "DATABASE_URL": "postgres://localhost:5432/mydb",
-        "DEBUG": "true"
-      }
-    }
-  }
-}
+{ "feature": { "env": { "exclude": "SECRET_*;LEGACY_*" } } }
 ```
 
-Overrides are applied after remote variables are loaded, so they take priority over both remote and local values.
+(`include` and `exclude` are mutually exclusive — pick one.)
 
-## Loading from a file
-
-You can load overrides from a dotenv-style file:
+**Override a value locally**
 
 ```json
-{
-  "feature": {
-    "env": {
-      "env_file": ".env.local"
-    }
-  }
-}
+{ "feature": { "env": { "override": { "REGION": "us-east-1" } } } }
 ```
 
-## Mapping variable names
-
-If your local code expects a different variable name than what the remote pod uses:
+**Merge in a local `.env`**
 
 ```json
-{
-  "feature": {
-    "env": {
-      "mapping": {
-        "REMOTE_DB_URL": "DATABASE_URL"
-      }
-    }
-  }
-}
+{ "feature": { "env": { "env_file": "./.env.local" } } }
 ```
 
-This maps the remote `REMOTE_DB_URL` value into the local `DATABASE_URL` variable.
-
-## Unsetting variables
-
-To ensure a remote variable is *not* present in your local process at all:
+**Remove a variable that confuses your tooling**
 
 ```json
-{
-  "feature": {
-    "env": {
-      "unset": "KUBERNETES_SERVICE_HOST;KUBERNETES_PORT"
-    }
-  }
-}
+{ "feature": { "env": { "unset": ["AWS_PROFILE"] } } }
 ```
 
-## Common scenarios
+This is the right fix when something like `AWS_PROFILE` from your shell makes the SDK ignore the remote credentials. `unset` is also the only way to strip variables when running Go (Go can't modify its env after start).
 
-**"My app connects to the wrong database locally"** The remote `DATABASE_URL` is being imported. Either override it with a local value, or exclude it.
+## Gotchas
 
-**"I need remote env vars but PATH keeps getting overwritten"** Exclude `PATH` (and other shell variables like `HOME`, `USER`, `SHELL`).
+- mirrord always strips toolchain variables (`PATH`, `HOME`, `JAVA_HOME`, `GOPATH`, `PYTHONPATH`, `CLASSPATH`, etc.) so your local interpreter doesn't break. You can't get these from the remote pod — they're considered local. See the [reference](../reference/env.md#always-excluded-variables) for the full list.
+- Variables set with `os.setenv()` (or equivalent) inside the running pod **won't appear** — mirrord reads `/proc/<pid>/environ`, which is fixed at process start.
 
-**"I want to test with a feature flag enabled"** Use `override` to set the flag value, regardless of what the remote pod has.
-
-For the full list of environment variable settings, see the [configuration reference](https://metalbear.com/mirrord/docs/config#feature.env).
-For a technical explanation of how environment variables work under the hood, see the [Environment Variables reference](../reference/env.md).
+For mechanism, full schema, post-fetch transformation order, and the complete excluded list, see the [environment variables reference](../reference/env.md).

--- a/docs/using-mirrord/file-operations.md
+++ b/docs/using-mirrord/file-operations.md
@@ -6,33 +6,26 @@ toc: true
 tags: ["open source", "team", "enterprise"]
 ---
 
-By default, mirrord redirects most file access from your local process to the remote pod. When your code opens `/etc/config/app.yaml`, it reads the remote pod's copy. This means your local process sees the same configuration files, certificates, and data that the deployed application does.
+By default, mirrord redirects most file reads from your local process to the remote pod. When your code opens `/etc/config/app.yaml`, it reads the remote pod's copy. Writes stay local. Your local process sees the same configuration files, certificates, and mounted volume data the deployed application does.
 
-Some paths, like language runtimes, package managers, and temp files, are always read locally. See the [full default list](https://github.com/metalbear-co/mirrord/blob/main/mirrord/layer-lib/src/file/unix/read_local_by_default.rs) for details.
+Some paths (language runtimes, package managers, home-directory state, temp files) are always read locally. See the [full default list](https://github.com/metalbear-co/mirrord/blob/main/mirrord/layer-lib/src/file/unix/read_local_by_default.rs) or the [reference](../reference/fileops.md#default-overrides).
 
 ## Choosing a mode
 
-mirrord supports three file system modes:
-
-| Mode | Behavior | Use when |
-|------|----------|----------|
-| `read` (default) | Reads from remote, writes locally | You want remote config but don't want to risk writing to remote files |
-| `local` | All file access stays local | You don't need any remote files |
-| `localwithoverrides` | All file access local, except paths you specify | You need just a few specific remote files |
+| Mode | Reads | Writes | Use when |
+|---|---|---|---|
+| `read` *(default)* | remote | local | You want remote config but don't want to risk writing to remote files |
+| `local` | local | local | You don't need any remote files |
+| `localwithoverrides` | local (except overrides) | local (except overrides) | You need just a few specific remote files |
+| `write` | remote | remote | Your app needs to write to a remote volume |
 
 ```json
-{
-  "feature": {
-    "fs": {
-      "mode": "read"
-    }
-  }
-}
+{ "feature": { "fs": { "mode": "read" } } }
 ```
 
-## Reading specific files remotely
+## Common patterns
 
-Use `localwithoverrides` when you only need a handful of remote files, for example a config file or TLS certificate:
+**Reading specific files remotely (rest stay local)**
 
 ```json
 {
@@ -45,11 +38,7 @@ Use `localwithoverrides` when you only need a handful of remote files, for examp
 }
 ```
 
-Paths support regex patterns.
-
-## Writing files remotely
-
-If your application writes to files that need to land on the remote filesystem (e.g. uploading to a shared volume), use `read_write`:
+**Writing to a specific remote path**
 
 ```json
 {
@@ -61,11 +50,9 @@ If your application writes to files that need to land on the remote filesystem (
 }
 ```
 
-Be careful with remote writes. They modify the actual remote pod's filesystem.
+Be careful — this modifies the actual remote pod's filesystem.
 
-## Keeping specific files local
-
-If the default `read` mode pulls in remote files that conflict with your local setup (e.g. `/tmp` files, lock files), you can force them to stay local:
+**Keeping specific paths local even in `read` mode**
 
 ```json
 {
@@ -77,13 +64,24 @@ If the default `read` mode pulls in remote files that conflict with your local s
 }
 ```
 
+**Hiding files that confuse a cluster-context process**
+
+If your local home dir has files (`.aws/credentials`, `.gcloud/`) that hijack auth when the process expects cluster auth:
+
+```json
+{
+  "feature": {
+    "fs": {
+      "not_found": ["\\.aws/credentials", "\\.config/gcloud"]
+    }
+  }
+}
+```
+
 ## Common scenarios
 
-**"My app reads config from a mounted ConfigMap"** The default `read` mode handles this. Your local process will read the ConfigMap contents from the remote pod.
+- **App reads config from a mounted ConfigMap** — default `read` mode handles this; no config needed.
+- **App writes logs locally** — default already writes locally; no change needed.
+- **App watches files with `inotify` for ConfigMap updates** — won't work; mirrord doesn't intercept inotify. Poll mtime via `stat` instead.
 
-**"My app writes logs to a file and I don't want them on the remote pod"** Default `read` mode already writes locally. No change needed.
-
-**"I only need one remote config file, everything else should be local"** Use `localwithoverrides` with the specific path.
-
-For the full list of file operation settings, see the [configuration reference](https://metalbear.com/mirrord/docs/config#feature.fs).
-For a technical explanation of how file operations work under the hood, see the [File Operations reference](../reference/fileops.md).
+For the full pattern resolution order, the complete list of intercepted syscalls, the default-override lists, path mapping (useful on Windows), and the readonly buffer setting, see the [file operations reference](../reference/fileops.md).

--- a/docs/using-mirrord/file-operations.md
+++ b/docs/using-mirrord/file-operations.md
@@ -50,7 +50,7 @@ Some paths (language runtimes, package managers, home-directory state, temp file
 }
 ```
 
-Be careful — this modifies the actual remote pod's filesystem.
+Be careful: this modifies the actual remote pod's filesystem.
 
 **Keeping specific paths local even in `read` mode**
 
@@ -80,8 +80,8 @@ If your local home dir has files (`.aws/credentials`, `.gcloud/`) that hijack au
 
 ## Common scenarios
 
-- **App reads config from a mounted ConfigMap** — default `read` mode handles this; no config needed.
-- **App writes logs locally** — default already writes locally; no change needed.
-- **App watches files with `inotify` for ConfigMap updates** — won't work; mirrord doesn't intercept inotify. Poll mtime via `stat` instead.
+- **App reads config from a mounted ConfigMap**: default `read` mode handles this; no config needed.
+- **App writes logs locally**: default already writes locally; no change needed.
+- **App watches files with `inotify` for ConfigMap updates**: won't work; mirrord doesn't intercept inotify. Poll mtime via `stat` instead.
 
 For the full pattern resolution order, the complete list of intercepted syscalls, the default-override lists, path mapping (useful on Windows), and the readonly buffer setting, see the [file operations reference](../reference/fileops.md).

--- a/docs/using-mirrord/file-operations.md
+++ b/docs/using-mirrord/file-operations.md
@@ -6,26 +6,34 @@ toc: true
 tags: ["open source", "team", "enterprise"]
 ---
 
-By default, mirrord redirects most file reads from your local process to the remote pod. When your code opens `/etc/config/app.yaml`, it reads the remote pod's copy. Writes stay local. Your local process sees the same configuration files, certificates, and mounted volume data the deployed application does.
+By default, mirrord redirects most file access from your local process to the remote pod. When your code opens `/etc/config/app.yaml`, it reads the remote pod's copy. This means your local process sees the same configuration files, certificates, and data that the deployed application does.
 
-Some paths (language runtimes, package managers, home-directory state, temp files) are always read locally. See the [full default list](https://github.com/metalbear-co/mirrord/blob/main/mirrord/layer-lib/src/file/unix/read_local_by_default.rs) or the [reference](../reference/fileops.md#default-overrides).
+Some paths, like language runtimes, package managers, and temp files, are always read locally. See the [full default list](https://github.com/metalbear-co/mirrord/blob/main/mirrord/layer-lib/src/file/unix/read_local_by_default.rs) for details.
 
 ## Choosing a mode
 
-| Mode | Reads | Writes | Use when |
-|---|---|---|---|
-| `read` *(default)* | remote | local | You want remote config but don't want to risk writing to remote files |
-| `local` | local | local | You don't need any remote files |
-| `localwithoverrides` | local (except overrides) | local (except overrides) | You need just a few specific remote files |
-| `write` | remote | remote | Your app needs to write to a remote volume |
+mirrord supports four file system modes:
+
+| Mode | Behavior | Use when |
+|------|----------|----------|
+| `read` (default) | Reads from remote, writes locally | You want remote config but don't want to risk writing to remote files |
+| `local` | All file access stays local | You don't need any remote files |
+| `localwithoverrides` | All file access local, except paths you specify | You need just a few specific remote files |
+| `write` | Reads from remote, writes to remote | Your app needs to write to a remote volume |
 
 ```json
-{ "feature": { "fs": { "mode": "read" } } }
+{
+  "feature": {
+    "fs": {
+      "mode": "read"
+    }
+  }
+}
 ```
 
-## Common patterns
+## Reading specific files remotely
 
-**Reading specific files remotely (rest stay local)**
+Use `localwithoverrides` when you only need a handful of remote files, for example a config file or TLS certificate:
 
 ```json
 {
@@ -38,7 +46,11 @@ Some paths (language runtimes, package managers, home-directory state, temp file
 }
 ```
 
-**Writing to a specific remote path**
+Paths support regex patterns.
+
+## Writing files remotely
+
+If your application writes to files that need to land on the remote filesystem (e.g. uploading to a shared volume), use `read_write`:
 
 ```json
 {
@@ -50,9 +62,11 @@ Some paths (language runtimes, package managers, home-directory state, temp file
 }
 ```
 
-Be careful: this modifies the actual remote pod's filesystem.
+Be careful with remote writes. They modify the actual remote pod's filesystem.
 
-**Keeping specific paths local even in `read` mode**
+## Keeping specific files local
+
+If the default `read` mode pulls in remote files that conflict with your local setup (e.g. `/tmp` files, lock files), you can force them to stay local:
 
 ```json
 {
@@ -64,9 +78,9 @@ Be careful: this modifies the actual remote pod's filesystem.
 }
 ```
 
-**Hiding files that confuse a cluster-context process**
+## Hiding files that confuse a cluster-context process
 
-If your local home dir has files (`.aws/credentials`, `.gcloud/`) that hijack auth when the process expects cluster auth:
+If your local home dir has files (`.aws/credentials`, `.gcloud/`) that hijack auth when the process expects cluster auth, mark them as not-found so the application gets `ENOENT`:
 
 ```json
 {
@@ -80,8 +94,13 @@ If your local home dir has files (`.aws/credentials`, `.gcloud/`) that hijack au
 
 ## Common scenarios
 
-- **App reads config from a mounted ConfigMap**: default `read` mode handles this; no config needed.
-- **App writes logs locally**: default already writes locally; no change needed.
-- **App watches files with `inotify` for ConfigMap updates**: won't work; mirrord doesn't intercept inotify. Poll mtime via `stat` instead.
+**"My app reads config from a mounted ConfigMap"** The default `read` mode handles this. Your local process will read the ConfigMap contents from the remote pod.
 
-For the full pattern resolution order, the complete list of intercepted syscalls, the default-override lists, path mapping (useful on Windows), and the readonly buffer setting, see the [file operations reference](../reference/fileops.md).
+**"My app writes logs to a file and I don't want them on the remote pod"** Default `read` mode already writes locally. No change needed.
+
+**"I only need one remote config file, everything else should be local"** Use `localwithoverrides` with the specific path.
+
+**"My app watches files with `inotify` for ConfigMap updates"** Won't work; mirrord doesn't intercept inotify. Poll mtime via `stat` instead.
+
+For the full list of file operation settings, see the [configuration reference](https://metalbear.com/mirrord/docs/config#feature.fs).
+For a technical explanation of how file operations work under the hood, see the [File Operations reference](../reference/fileops.md).

--- a/docs/using-mirrord/incoming-traffic/README.md
+++ b/docs/using-mirrord/incoming-traffic/README.md
@@ -3,15 +3,17 @@ title: Incoming Traffic
 description: How mirrord handles incoming network traffic from the cluster
 ---
 
-mirrord lets your local process receive network traffic that would normally go to a pod in the cluster. There are two main modes (plus `off`):
+mirrord lets your local process receive network traffic that would normally go to a pod in the cluster. There are two main modes (plus `off` to disable):
 
 ## Mirroring (default)
 
-mirrord **mirrors** incoming TCP traffic: your local process receives a copy while the remote pod continues to handle it normally. Responses from your local process are dropped. This is a safe, read-only way to observe how your code handles real requests.
+In the default configuration, mirrord **mirrors** incoming TCP traffic - your local process receives a copy of the traffic while the remote pod continues to handle it normally. Responses from your local process are dropped. This is a safe, read-only way to observe how your code handles real requests.
 
 ## Stealing
 
-In **steal** mode, mirrord intercepts incoming traffic and redirects it to your local process instead of the remote pod. Your local process becomes the one responding to real requests. Useful when you need to test how your code handles and responds to live traffic.
+In **steal** mode, mirrord intercepts incoming traffic and redirects it to your local process instead of the remote pod. Your local process becomes the one responding to real requests. This is useful when you need to test how your code handles and responds to live traffic.
+
+Steal mode can be configured in your mirrord config:
 
 ```json
 {
@@ -23,14 +25,12 @@ In **steal** mode, mirrord intercepts incoming traffic and redirects it to your 
 }
 ```
 
-When sharing a cluster, almost always combine `steal` with a [filter](filter-incoming-traffic.md) so you only steal *your* traffic.
-
-For mode semantics, HTTP detection behavior, all configuration fields (`port_mapping`, `ignore_ports`, `on_concurrent_steal`, etc.), and the operator-only options, see the [traffic reference](../../reference/traffic.md#incoming-traffic).
+When sharing a cluster, almost always combine `steal` with a [filter](filter-incoming-traffic.md) so you only steal *your* traffic. For the full configuration surface (`port_mapping`, `ignore_ports`, `on_concurrent_steal`, etc.) and the operator-only options, see the [traffic reference](../../reference/traffic.md#incoming-traffic).
 
 ## What's in this section
 
-- **[Filter Incoming Traffic](filter-incoming-traffic.md)**: Steal only a subset of traffic using HTTP header, W3C `baggage`/`tracestate`, path, method, body, or jq filters
-  - [Filtering by JSON Body](filtering-by-json-body.md): Filter based on request body content
-  - [Debug from Browser](debug-from-browser.md): Use the Chrome extension to route browser traffic to your local process
-- **[Steal HTTPS Requests](steal-https.md)** **[Teams]**: Decrypt and steal HTTPS traffic using TLS certificates
-- **[Inspect Live Traffic](inspect-live-traffic.md)**: Monitor incoming traffic without running a local process
+- **[Filter Incoming Traffic](filter-incoming-traffic.md)** - Steal only a subset of traffic using HTTP header, W3C `baggage`/`tracestate`, path, method, body, or jq filters
+  - [Filtering by JSON Body](filtering-by-json-body.md) - Filter based on request body content
+  - [Debug from Browser](debug-from-browser.md) - Use the Chrome extension to route browser traffic to your local process
+- **[Steal HTTPS Requests](steal-https.md)** **[Teams]** - Decrypt and steal HTTPS traffic using TLS certificates
+- **[Inspect Live Traffic](inspect-live-traffic.md)** - Monitor incoming traffic without running a local process

--- a/docs/using-mirrord/incoming-traffic/README.md
+++ b/docs/using-mirrord/incoming-traffic/README.md
@@ -7,7 +7,7 @@ mirrord lets your local process receive network traffic that would normally go t
 
 ## Mirroring (default)
 
-mirrord **mirrors** incoming TCP traffic — your local process receives a copy while the remote pod continues to handle it normally. Responses from your local process are dropped. This is a safe, read-only way to observe how your code handles real requests.
+mirrord **mirrors** incoming TCP traffic: your local process receives a copy while the remote pod continues to handle it normally. Responses from your local process are dropped. This is a safe, read-only way to observe how your code handles real requests.
 
 ## Stealing
 
@@ -29,8 +29,8 @@ For mode semantics, HTTP detection behavior, all configuration fields (`port_map
 
 ## What's in this section
 
-- **[Filter Incoming Traffic](filter-incoming-traffic.md)** — Steal only a subset of traffic using HTTP header, W3C `baggage`/`tracestate`, path, method, body, or jq filters
-  - [Filtering by JSON Body](filtering-by-json-body.md) — Filter based on request body content
-  - [Debug from Browser](debug-from-browser.md) — Use the Chrome extension to route browser traffic to your local process
-- **[Steal HTTPS Requests](steal-https.md)** **[Teams]** — Decrypt and steal HTTPS traffic using TLS certificates
-- **[Inspect Live Traffic](inspect-live-traffic.md)** — Monitor incoming traffic without running a local process
+- **[Filter Incoming Traffic](filter-incoming-traffic.md)**: Steal only a subset of traffic using HTTP header, W3C `baggage`/`tracestate`, path, method, body, or jq filters
+  - [Filtering by JSON Body](filtering-by-json-body.md): Filter based on request body content
+  - [Debug from Browser](debug-from-browser.md): Use the Chrome extension to route browser traffic to your local process
+- **[Steal HTTPS Requests](steal-https.md)** **[Teams]**: Decrypt and steal HTTPS traffic using TLS certificates
+- **[Inspect Live Traffic](inspect-live-traffic.md)**: Monitor incoming traffic without running a local process

--- a/docs/using-mirrord/incoming-traffic/README.md
+++ b/docs/using-mirrord/incoming-traffic/README.md
@@ -3,17 +3,15 @@ title: Incoming Traffic
 description: How mirrord handles incoming network traffic from the cluster
 ---
 
-mirrord lets your local process receive network traffic that would normally go to a pod in the cluster. There are two modes:
+mirrord lets your local process receive network traffic that would normally go to a pod in the cluster. There are two main modes (plus `off`):
 
 ## Mirroring (default)
 
-In the default configuration, mirrord **mirrors** incoming TCP traffic - your local process receives a copy of the traffic while the remote pod continues to handle it normally. Responses from your local process are dropped. This is a safe, read-only way to observe how your code handles real requests.
+mirrord **mirrors** incoming TCP traffic — your local process receives a copy while the remote pod continues to handle it normally. Responses from your local process are dropped. This is a safe, read-only way to observe how your code handles real requests.
 
 ## Stealing
 
-In **steal** mode, mirrord intercepts incoming traffic and redirects it to your local process instead of the remote pod. Your local process becomes the one responding to real requests. This is useful when you need to test how your code handles and responds to live traffic.
-
-Steal mode can be configured in your mirrord config:
+In **steal** mode, mirrord intercepts incoming traffic and redirects it to your local process instead of the remote pod. Your local process becomes the one responding to real requests. Useful when you need to test how your code handles and responds to live traffic.
 
 ```json
 {
@@ -25,10 +23,14 @@ Steal mode can be configured in your mirrord config:
 }
 ```
 
+When sharing a cluster, almost always combine `steal` with a [filter](filter-incoming-traffic.md) so you only steal *your* traffic.
+
+For mode semantics, HTTP detection behavior, all configuration fields (`port_mapping`, `ignore_ports`, `on_concurrent_steal`, etc.), and the operator-only options, see the [traffic reference](../../reference/traffic.md#incoming-traffic).
+
 ## What's in this section
 
-- **[Filter Incoming Traffic](filter-incoming-traffic.md)** - Steal only a subset of traffic using HTTP header, W3C `baggage`/`tracestate`, path, or method filters
-  - [Filtering by JSON Body](filtering-by-json-body.md) - Filter based on request body content
-  - [Debug from Browser](debug-from-browser.md) - Use the Chrome extension to route browser traffic to your local process
-- **[Steal HTTPS Requests](steal-https.md)** **[Teams]** - Decrypt and steal HTTPS traffic using TLS certificates
-- **[Inspect Live Traffic](inspect-live-traffic.md)** - Monitor incoming traffic without running a local process
+- **[Filter Incoming Traffic](filter-incoming-traffic.md)** — Steal only a subset of traffic using HTTP header, W3C `baggage`/`tracestate`, path, method, body, or jq filters
+  - [Filtering by JSON Body](filtering-by-json-body.md) — Filter based on request body content
+  - [Debug from Browser](debug-from-browser.md) — Use the Chrome extension to route browser traffic to your local process
+- **[Steal HTTPS Requests](steal-https.md)** **[Teams]** — Decrypt and steal HTTPS traffic using TLS certificates
+- **[Inspect Live Traffic](inspect-live-traffic.md)** — Monitor incoming traffic without running a local process

--- a/docs/using-mirrord/outgoing-traffic/README.md
+++ b/docs/using-mirrord/outgoing-traffic/README.md
@@ -3,20 +3,22 @@ title: Outgoing Traffic
 description: How mirrord handles outgoing network traffic from your local process
 ---
 
-By default, mirrord intercepts outgoing network requests from your local process and routes them through the remote pod. This means your local code can access cluster-internal services - databases, APIs, message brokers - as if it were running inside the cluster.
+By default, mirrord intercepts outgoing network requests from your local process and routes them through the remote pod. Your local code can access cluster-internal services — databases, APIs, message brokers — as if it were running inside the cluster.
 
 This works through three mechanisms:
 
-1. **Environment variables** - Your local process inherits the remote pod's environment variables, so connection strings and hostnames point to the right places
-2. **DNS resolution** - mirrord resolves DNS queries in the context of the remote pod, so cluster-internal hostnames (like `my-service.default.svc.cluster.local`) resolve correctly
-3. **Network interception** - Outgoing TCP and UDP connections are sent from the remote pod, giving your local process access to resources that are only reachable from within the cluster
+1. **Environment variables** — your local process inherits the remote pod's env, so connection strings and hostnames point to the right places.
+2. **DNS resolution** — mirrord resolves DNS queries in the pod's context, so cluster-internal hostnames (like `my-service.default.svc.cluster.local`) resolve correctly.
+3. **Network interception** — outgoing TCP and UDP connections are sent from the remote pod, giving your local process access to resources that are only reachable from within the cluster.
 
 Both outgoing TCP and UDP forwarding are enabled by default.
 
 {% hint style="warning" %}
-If mirrord is configured to **mirror** incoming traffic, both the remote pod and your local process may make outgoing API calls for the same incoming request. If those calls are write operations (e.g. database inserts), this could lead to duplicates. Consider using [steal mode](../incoming-traffic/README.md) or disabling outgoing traffic forwarding to avoid this.
+If mirrord is configured to **mirror** incoming traffic (the default), both the remote pod and your local process may make outgoing API calls for the same incoming request. If those calls are write operations (e.g. database inserts), this leads to duplicates. Use [`steal` mode](../incoming-traffic/README.md), disable outgoing traffic, or use an [outgoing filter](filter-outgoing-traffic.md) to avoid it.
 {% endhint %}
+
+For the full config surface (TCP/UDP toggles, `ignore_localhost`, filter syntax, Unix-socket forwarding), the DNS-resolution caveats, and IPv6 support, see the [traffic reference](../../reference/traffic.md#outgoing-traffic).
 
 ## What's in this section
 
-- **[Filter Outgoing Traffic](filter-outgoing-traffic.md)** - Control which outgoing connections go through the cluster and which stay local
+- **[Filter Outgoing Traffic](filter-outgoing-traffic.md)** — control which outgoing connections go through the cluster and which stay local

--- a/docs/using-mirrord/outgoing-traffic/README.md
+++ b/docs/using-mirrord/outgoing-traffic/README.md
@@ -3,22 +3,22 @@ title: Outgoing Traffic
 description: How mirrord handles outgoing network traffic from your local process
 ---
 
-By default, mirrord intercepts outgoing network requests from your local process and routes them through the remote pod. Your local code can access cluster-internal services like databases, APIs, and message brokers, as if it were running inside the cluster.
+By default, mirrord intercepts outgoing network requests from your local process and routes them through the remote pod. This means your local code can access cluster-internal services - databases, APIs, message brokers - as if it were running inside the cluster.
 
 This works through three mechanisms:
 
-1. **Environment variables**: your local process inherits the remote pod's env, so connection strings and hostnames point to the right places.
-2. **DNS resolution**: mirrord resolves DNS queries in the pod's context, so cluster-internal hostnames (like `my-service.default.svc.cluster.local`) resolve correctly.
-3. **Network interception**: outgoing TCP and UDP connections are sent from the remote pod, giving your local process access to resources that are only reachable from within the cluster.
+1. **Environment variables** - Your local process inherits the remote pod's environment variables, so connection strings and hostnames point to the right places
+2. **DNS resolution** - mirrord resolves DNS queries in the context of the remote pod, so cluster-internal hostnames (like `my-service.default.svc.cluster.local`) resolve correctly
+3. **Network interception** - Outgoing TCP and UDP connections are sent from the remote pod, giving your local process access to resources that are only reachable from within the cluster
 
 Both outgoing TCP and UDP forwarding are enabled by default.
 
 {% hint style="warning" %}
-If mirrord is configured to **mirror** incoming traffic (the default), both the remote pod and your local process may make outgoing API calls for the same incoming request. If those calls are write operations (e.g. database inserts), this leads to duplicates. Use [`steal` mode](../incoming-traffic/README.md), disable outgoing traffic, or use an [outgoing filter](filter-outgoing-traffic.md) to avoid it.
+If mirrord is configured to **mirror** incoming traffic (the default), both the remote pod and your local process may make outgoing API calls for the same incoming request. If those calls are write operations (e.g. database inserts), this could lead to duplicates. Use [steal mode](../incoming-traffic/README.md), disable outgoing traffic forwarding, or use an [outgoing filter](filter-outgoing-traffic.md) to avoid this.
 {% endhint %}
 
-For the full config surface (TCP/UDP toggles, `ignore_localhost`, filter syntax, Unix-socket forwarding), the DNS-resolution caveats, and IPv6 support, see the [traffic reference](../../reference/traffic.md#outgoing-traffic).
+For the full config surface (TCP/UDP toggles, `ignore_localhost`, filter syntax, Unix-socket forwarding), DNS-resolution caveats, and IPv6 support, see the [traffic reference](../../reference/traffic.md#outgoing-traffic).
 
 ## What's in this section
 
-- **[Filter Outgoing Traffic](filter-outgoing-traffic.md)**: control which outgoing connections go through the cluster and which stay local
+- **[Filter Outgoing Traffic](filter-outgoing-traffic.md)** - Control which outgoing connections go through the cluster and which stay local

--- a/docs/using-mirrord/outgoing-traffic/README.md
+++ b/docs/using-mirrord/outgoing-traffic/README.md
@@ -3,13 +3,13 @@ title: Outgoing Traffic
 description: How mirrord handles outgoing network traffic from your local process
 ---
 
-By default, mirrord intercepts outgoing network requests from your local process and routes them through the remote pod. Your local code can access cluster-internal services — databases, APIs, message brokers — as if it were running inside the cluster.
+By default, mirrord intercepts outgoing network requests from your local process and routes them through the remote pod. Your local code can access cluster-internal services like databases, APIs, and message brokers, as if it were running inside the cluster.
 
 This works through three mechanisms:
 
-1. **Environment variables** — your local process inherits the remote pod's env, so connection strings and hostnames point to the right places.
-2. **DNS resolution** — mirrord resolves DNS queries in the pod's context, so cluster-internal hostnames (like `my-service.default.svc.cluster.local`) resolve correctly.
-3. **Network interception** — outgoing TCP and UDP connections are sent from the remote pod, giving your local process access to resources that are only reachable from within the cluster.
+1. **Environment variables**: your local process inherits the remote pod's env, so connection strings and hostnames point to the right places.
+2. **DNS resolution**: mirrord resolves DNS queries in the pod's context, so cluster-internal hostnames (like `my-service.default.svc.cluster.local`) resolve correctly.
+3. **Network interception**: outgoing TCP and UDP connections are sent from the remote pod, giving your local process access to resources that are only reachable from within the cluster.
 
 Both outgoing TCP and UDP forwarding are enabled by default.
 
@@ -21,4 +21,4 @@ For the full config surface (TCP/UDP toggles, `ignore_localhost`, filter syntax,
 
 ## What's in this section
 
-- **[Filter Outgoing Traffic](filter-outgoing-traffic.md)** — control which outgoing connections go through the cluster and which stay local
+- **[Filter Outgoing Traffic](filter-outgoing-traffic.md)**: control which outgoing connections go through the cluster and which stay local


### PR DESCRIPTION
## Summary

Re-anchors the Reference vs Using-mirrord split that drifted toward a shallow middle. **Reference** pages are now technical deep-dives (mechanism, full config surface, edge cases); **Using mirrord** pages are quick how-tos that link out to Reference. All 5 Reference pages rewritten and verified against the [mirrord source](https://github.com/metalbear-co/mirrord); 4 of the overlapping Using pages thinned.

GitBook will publish a preview — please check the *GitBook - metalbear.com* link below.

## Pages changed

### Reference (deep-dive rewrites)
- `reference/architecture.md` — adds `mirrord-intproxy`, `mirrord-operator`, `mirrord-external-proxy` (all previously unmentioned); refreshed ASCII component diagram + full session-lifecycle walkthrough
- `reference/targets.md` — adds OSS-vs-Teams replica handling, container-selection rules (sidecar skip), explicit precedence order across CLI / env / config / IDE
- `reference/traffic.md` — adds `method`/`body`/`jq`/composite HTTP filters, `port_mapping`, `listen_ports`, `ignore_ports`, `on_concurrent_steal`, `tls_delivery`, IPv6, full DNS surface, the DNS-resolver-on-port-53 caveat
- `reference/env.md` — adds the always-excluded list (`PATH`, `HOME`, `GOPATH`, `JAVA_HOME`, `CLASSPATH`, etc.), full surface (`override`/`mapping`/`env_file`/`unset`/`load_from_process`), post-fetch transformation order
- `reference/fileops.md` — expands intercepted-syscalls list from 6 to 24+, adds default-override lists (local-by-default, remote-by-default, not-found-by-default), resolution order, `mapping` (incl. Windows path translation), `inotify` limitation

### Using mirrord (thinned how-tos)
- `using-mirrord/environment-variables.md` — quick-start + common patterns + 2 gotchas; mechanism moved to Reference
- `using-mirrord/file-operations.md` — **adds missing `write` mode** to the modes table; trims internals
- `using-mirrord/incoming-traffic/README.md` — minor: corrects "two modes" → "two main modes plus off", adds cluster-sharing note
- `using-mirrord/outgoing-traffic/README.md` — minor: trims config-surface duplication, links to Reference

### Untouched
- All `incoming-traffic/*` child pages (filter-incoming-traffic, steal-https, filtering-by-json-body, debug-from-browser, inspect-live-traffic) and `outgoing-traffic/filter-outgoing-traffic` — already correctly shaped as feature-specific how-tos
- `using-mirrord/targetless.md` and `using-mirrord/copy-target.md` — already feature-focused

## Bugs / outdated content fixed

1. **`reference/traffic.md` HTTP filter port default** — was *"By default, ports 80 and 8080 are used as HTTP ports if a filter is specified"*. Actual default is **all listened ports** when `http_filter.ports` is absent. ([config code](https://github.com/metalbear-co/mirrord/blob/latest/mirrord/config/src/feature/network/incoming/http_filter.rs))
2. **`reference/env.md` deprecated CLI examples** — was showing `--override-env-vars-include` / `--override-env-vars-exclude`. Current surface is `feature.env.include` / `feature.env.exclude`.
3. **`using-mirrord/file-operations.md` missing `write` mode** — table listed only 3 of the 4 modes.
4. **`reference/fileops.md` understated syscall list** — said "six overridden functions". Actual: 24+ unique hooks across categories. ([hooks.rs](https://github.com/metalbear-co/mirrord/blob/latest/mirrord/layer/src/file/hooks.rs))
5. **`reference/architecture.md` missing components** — intproxy and operator (and external-proxy for container mode) weren't mentioned at all.

Plus the always-excluded env var list (PATH, HOME, GOPATH, JAVA_HOME, etc.), which was undocumented and surprises users when they `include` one and it doesn't show up.

## Frame

Reference vs Using readers want different things:

- **Reference reader**: "I want to know exactly what this feature does, all the knobs, the corner cases, and the mechanism."
- **Using reader**: "I want to do the thing. Show me the minimal config and the most common patterns."

Trying to serve both with one prose layer ended up serving neither — Reference grew thin, Using grew technical, and they overlapped on the middle band. This PR pushes them back to their poles.

## Test plan

- [ ] Check the GitBook preview link — verify each page renders, table widths are OK, ASCII diagrams display, internal links work
- [ ] Spot-check Reference claims against the linked source code paths
- [ ] Verify the Using pages still answer the common how-to without needing the Reference deep dive for basic tasks

🤖 Generated with [Claude Code](https://claude.com/claude-code)