### PR TITLE
docs: consistent Enterprise hint placement on gated pages

### DIFF
--- a/docs/use-cases/mirrord-for-ci.md
+++ b/docs/use-cases/mirrord-for-ci.md
@@ -29,6 +29,10 @@ it as a background process.
 The `mirrord ci start` command is more appropriate for this use case, since it starts your app and mirrord as
 background processes, allowing you to then run tests while your app is running in the background and connected to the cluster.
 
+{% hint style="info" %}
+This feature is available to users on the Enterprise pricing plan.
+{% endhint %}
+
 ## Prerequisites
 
 1. Minimum mirrord CLI version `3.181.0`.

--- a/docs/using-mirrord/multi-cluster.md
+++ b/docs/using-mirrord/multi-cluster.md
@@ -2,11 +2,11 @@
 title: "Seamless Multi-Cluster Development"
 ---
 
+Multi-cluster mirrord lets developers intercept traffic from pods running in multiple Kubernetes clusters at the same time, without switching kube contexts or managing multiple sessions. You run `mirrord exec` exactly like before, and the operator handles everything behind the scenes.
+
 {% hint style="info" %}
 This feature is available to users on the Enterprise pricing plan.
 {% endhint %}
-
-Multi-cluster mirrord lets developers intercept traffic from pods running in multiple Kubernetes clusters at the same time, without switching kube contexts or managing multiple sessions. You run `mirrord exec` exactly like before, and the operator handles everything behind the scenes.
 
 **When is this useful?**
 


### PR DESCRIPTION
## Summary
- **mirrord for CI** — page was missing the Enterprise license hint that every other gated use-case / feature page carries (Preview Environments, License Server, multi-cluster, queue splitting, db branching, profiles, HA, etc.). Visitors had no in-page indication it was Enterprise-gated.
- **multi-cluster** — hint was directly under the H1; ~16 other gated pages place it after the lead paragraph and before the first H2. Moved multi-cluster's hint to match the majority pattern: lead paragraph → Enterprise hint → first H2.

## Test plan
- [ ] Render the mirrord for CI page and confirm the Enterprise hint appears after the intro paragraphs and before \`## Prerequisites\`.
- [ ] Render the multi-cluster page and confirm the Enterprise hint now appears after the lead paragraph and before "When is this useful?".

🤖 Generated with [Claude Code](https://claude.com/claude-code)