### PR TITLE
SEO: disambiguate duplicate docs titles (42DM audit)

### DIFF
--- a/docs/reference/env.md
+++ b/docs/reference/env.md
@@ -1,5 +1,5 @@
 ---
-title: Environment Variables
+title: Environment Variables Reference
 date: 2022-06-15T08:48:45.000Z
 lastmod: 2022-06-15T08:48:45.000Z
 draft: false

--- a/docs/reference/fileops.md
+++ b/docs/reference/fileops.md
@@ -1,5 +1,5 @@
 ---
-title: "File Operations"
+title: "File Operations Reference"
 description: "Reference to mirrord's file operations"
 date: 2022-06-15T08:48:45+00:00
 lastmod: 2022-06-15T08:48:45+00:00


### PR DESCRIPTION
Fixes the only **substantive** part of the 42DM "Titles Length" finding for the docs: **duplicate titles**.

Two `reference/` pages shared a title with their `using-mirrord/` counterparts — duplicate `<title>` *and* duplicate H1 (GitBook renders the page `title` as the H1), which causes keyword cannibalization:

| Page | Before | After |
|---|---|---|
| `reference/env` | Environment Variables | **Environment Variables Reference** |
| `reference/fileops` | File Operations | **File Operations Reference** |

This matches the auditor's own H1-Fixes spec and clears both the **Duplicate-Title** and **Duplicate-H1** findings for these pages.

## Not changed
The audit also flags every docs title as "under 40 chars." Left as-is on purpose: GitBook ties the page `title` to the visible on-page H1 (no separate SEO-title field), so padding concise headings like "Quick Start" / "Architecture" to 40–60 chars would worsen the docs reading experience for no real SEO gain. Short, unique, descriptive titles are fine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
