### PR TITLE
SEO: fix stale internal docs link (db-branching)

### DIFF
--- a/docs/using-mirrord-with-ai/ai-skills-plugin.md
+++ b/docs/using-mirrord-with-ai/ai-skills-plugin.md
@@ -17,7 +17,7 @@ Skills are reusable instruction modules that teach AI agents how to work with mi
 - Guide you through installation and your first mirrord session
 - Help set up mirrord in CI pipelines
 - Configure the mirrord operator for team environments
-- Help set up [database branching](../using-mirrord/db-branching.md) for your cluster
+- Help set up [database branching](../sharing-the-cluster/db-branching.md) for your cluster
 
 
 ## Available Skills


### PR DESCRIPTION
One stale internal link: `db-branching` moved from `using-mirrord/` to `sharing-the-cluster/`, so `ai-skills-plugin.md` linked to a redirecting path. Updated the relative link. (42DM audit — internal 3xx.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)