### PR TITLE
SEO: canonical docs links in guides (42DM audit)

### DIFF
--- a/guides/ai-docs-content-to-extract.md
+++ b/guides/ai-docs-content-to-extract.md
@@ -1,6 +1,6 @@
 # Content to add to the AI section of the docs
 
-> This file is NOT a guide. It contains the "why" content extracted from the guides that should be added to the [Using mirrord with AI Agents](https://metalbear.com/mirrord/docs/using-mirrord-with-ai) docs page (or a new sibling page). Delete this file after the content has been moved.
+> This file is NOT a guide. It contains the "why" content extracted from the guides that should be added to the [Using mirrord with AI Agents](https://metalbear.com/mirrord/docs/use-cases/using-mirrord-with-ai) docs page (or a new sibling page). Delete this file after the content has been moved.
 
 ---
 

--- a/guides/how-to-debug-a-dotnet-microservice.md
+++ b/guides/how-to-debug-a-dotnet-microservice.md
@@ -94,7 +94,7 @@ The microservice needs access to the "redis" service hosted on the cluster. To r
 
 2. Installing mirrord
 
-Install the mirrord CLI to run the Guestbook service within the context of the cluster so that it is able to communicate with the redis service in the cluster. Follow the installation guide for mirrord [here](https://metalbear.com/mirrord/docs/overview/quick-start/#installation).
+Install the mirrord CLI to run the Guestbook service within the context of the cluster so that it is able to communicate with the redis service in the cluster. Follow the installation guide for mirrord [here](https://metalbear.com/mirrord/docs/getting-started/quick-start#installation).
 
 3. Run the Guestbook application with dotnet and mirrord in the CLI
 
@@ -176,7 +176,7 @@ Let's add a new config file for mirrord, which we can use with VS Code for debug
 ```
 
 
-If you want to steal traffic from a multipod deployment, you can learn more about [mirrord for Teams](https://metalbear.com/mirrord/docs/overview/teams/) which provides this feature. Right now, we only have one pod in this deployment, and mirrord's OSS features should work perfectly for us.
+If you want to steal traffic from a multipod deployment, you can learn more about [mirrord for Teams](https://metalbear.com/mirrord/docs/getting-started/what-is-mirrord) which provides this feature. Right now, we only have one pod in this deployment, and mirrord's OSS features should work perfectly for us.
 
 To ensure that the configuration file created is read by the VS Code mirrord extension, hover over the mirrord button we mentioned earlier and press the 'Select active config' option. From the given prompt, enter the location of the configuration to be consumed by the plugin.
 

--- a/guides/how-to-debug-a-go-microservice.md
+++ b/guides/how-to-debug-a-go-microservice.md
@@ -162,7 +162,7 @@ Let’s update the new config file created and opened in the editor. The configu
 }
 ```
 
-If you want to mirror traffic from a multipod deployment, you can learn more about mirrord for teams [/mirrord/docs/overview/teams/](https://metalbear.com/mirrord/docs/overview/teams/) which provides this feature. Right now we only have one pod in this deployment and mirrord’s OSS features should work perfectly for us.
+If you want to mirror traffic from a multipod deployment, you can learn more about mirrord for teams [/mirrord/docs/overview/teams/](https://metalbear.com/mirrord/docs/getting-started/what-is-mirrord) which provides this feature. Right now we only have one pod in this deployment and mirrord’s OSS features should work perfectly for us.
 
 2. **Run the application with and without mirrord in the Goland IDE?**
 
@@ -207,7 +207,7 @@ Now that we can run the application, let’s understand what our setup looks lik
 
 ![alt text](how-to-debug-a-go-microservice/screenshot-2024-12-20-at-08-14-59-1.png)
 
-If you would like to learn more about how the mirrord-agent in the above architecture works, go check out the reference here [/mirrord/docs/reference/architecture/#mirrord-agent](https://metalbear.com/mirrord/docs/reference/architecture/#mirrord-agent).
+If you would like to learn more about how the mirrord-agent in the above architecture works, go check out the reference here [/mirrord/docs/reference/architecture/#mirrord-agent](https://metalbear.com/mirrord/docs/reference/architecture#mirrord-agent).
 
 We can now be sure that mirrord is working properly. 
 
@@ -246,7 +246,7 @@ The microservice needs access to the “redis” service hosted on the cluster. 
 
 2. **Installing mirrord**
 
-Install the mirrord CLI tool and run Guestbook with the required Kubernetes context. Follow the installation guide for mirrord here [/mirrord/docs/overview/quick-start/#installation](https://metalbear.com/mirrord/docs/overview/quick-start/#installation) and run the below command.
+Install the mirrord CLI tool and run Guestbook with the required Kubernetes context. Follow the installation guide for mirrord here [/mirrord/docs/overview/quick-start/#installation](https://metalbear.com/mirrord/docs/getting-started/quick-start#installation) and run the below command.
 
 3. **Run the Guestbook application with go and mirrord in the CLI**
 

--- a/guides/how-to-debug-a-java-microservice.md
+++ b/guides/how-to-debug-a-java-microservice.md
@@ -143,7 +143,7 @@ As a new config file is opened up in your editor, you can update the contents of
 }
 ```
 
-If you want to mirror traffic from a multipod deployment, you can learn more about mirrord for teams [/mirrord/docs/overview/teams/](https://metalbear.com/mirrord/docs/overview/teams/) which provides this feature. Right now we only have one pod in this deployment and mirrord’s OSS features should work perfectly for us.
+If you want to mirror traffic from a multipod deployment, you can learn more about mirrord for teams [/mirrord/docs/overview/teams/](https://metalbear.com/mirrord/docs/getting-started/what-is-mirrord) which provides this feature. Right now we only have one pod in this deployment and mirrord’s OSS features should work perfectly for us.
 
 #### Testrun without mirrord enabled
 
@@ -182,7 +182,7 @@ Now that we are able to run the application, let’s understand what our setup l
 
 ![alt text](how-to-debug-a-java-microservice/screenshot-2024-12-03-at-08-43-53-1.png)
 
-If you would like to learn more about how the mirrord-agent in the above architecture works, go checkout the reference here [/mirrord/docs/reference/architecture/#mirrord-agent](https://metalbear.com/mirrord/docs/reference/architecture/#mirrord-agent).
+If you would like to learn more about how the mirrord-agent in the above architecture works, go checkout the reference here [/mirrord/docs/reference/architecture/#mirrord-agent](https://metalbear.com/mirrord/docs/reference/architecture#mirrord-agent).
 
 We can now be sure that mirrord is working properly.
 
@@ -221,7 +221,7 @@ The microservice needs access to the “mongo” and “minio” services hosted
 
 #### Installing mirrord
 
-Let’s install mirrord CLI tool and run knote with the required Kubernetes context. Follow the installation guide for mirrord here [/mirrord/docs/overview/quick-start/#installation](https://metalbear.com/mirrord/docs/overview/quick-start/#installation) and run the below command.
+Let’s install mirrord CLI tool and run knote with the required Kubernetes context. Follow the installation guide for mirrord here [/mirrord/docs/overview/quick-start/#installation](https://metalbear.com/mirrord/docs/getting-started/quick-start#installation) and run the below command.
 
 #### Running the SpringBoot application with mirrord
 

--- a/guides/how-to-debug-a-kotlin-microservice.md
+++ b/guides/how-to-debug-a-kotlin-microservice.md
@@ -142,7 +142,7 @@ As a new config file is opened up in your editor, you can update the contents of
 }
 ```
 
-If you want to mirror traffic from a multipod deployment, you can learn more about [mirrord for teams]( /mirrord/docs/overview/teams/) which provides this feature. Right now we only have one pod in this deployment and mirrord’s OSS features should work perfectly for us.
+If you want to mirror traffic from a multipod deployment, you can learn more about [mirrord for teams]( /mirrord/docs/getting-started/what-is-mirrord) which provides this feature. Right now we only have one pod in this deployment and mirrord’s OSS features should work perfectly for us.
 
 ### 2. How to run the application with and without mirrord in IntelliJ IDEA?
 
@@ -182,7 +182,7 @@ Now that we can run the application, let’s understand what our setup looks lik
 ![debugging apps in mirrord](how-to-debug-a-kotlin-microservice/screenshot-2025-03-14-at-4-04-09pm.png)
 
 
-If you would like to learn more about how the mirrord-agent in the above architecture works, go check out the reference [here](https://metalbear.com/mirrord/docs/reference/architecture/#mirrord-agent).
+If you would like to learn more about how the mirrord-agent in the above architecture works, go check out the reference [here](https://metalbear.com/mirrord/docs/reference/architecture#mirrord-agent).
 
 We can now be sure that mirrord is working properly. 
 
@@ -217,7 +217,7 @@ On the run above we can see that the application run fails because this local ex
 
 The microservice needs access to the “redis” service hosted on the cluster. To run the microservice with Kubernetes, we can use the mirrord CLI tool.
 ### 2. Install mirrord
-Let’s install the mirrord CLI tool and run kotlin-guestbook with the required Kubernetes context. Follow the installation guide for mirrord [here](https://metalbear.com/mirrord/docs/overview/quick-start/#installation) and run the below command.
+Let’s install the mirrord CLI tool and run kotlin-guestbook with the required Kubernetes context. Follow the installation guide for mirrord [here](https://metalbear.com/mirrord/docs/getting-started/quick-start#installation) and run the below command.
 
 ### 3. Run the application with Maven and mirrord in the CLI
 ```

--- a/guides/how-to-debug-a-nodejs-microservice.md
+++ b/guides/how-to-debug-a-nodejs-microservice.md
@@ -138,7 +138,7 @@ Let’s add a new config file for mirrord, which we can use with VSCode for debu
 ```
 
 
-If you want to mirror traffic from a multipod deployment, you can learn more about mirrord for teams /mirrord/docs/overview/teams/ which provides this feature. Right now, we only have one pod in this deployment, and mirrord’s OSS features should work perfectly for us.
+If you want to mirror traffic from a multipod deployment, you can learn more about mirrord for teams /mirrord/docs/getting-started/what-is-mirrord which provides this feature. Right now, we only have one pod in this deployment, and mirrord’s OSS features should work perfectly for us.
 
 To ensure that the configuration file created is read by the VSCode mirrord extension, hover over the mirrord button we mentioned earlier and press the ‘Select active config’ option. From the given prompt, enter the location of the configuration to be consumed by the plugin.
 
@@ -203,7 +203,7 @@ Now that we can run the application, let’s understand what our setup looks lik
 ![alt text](how-to-debug-a-nodejs-microservice/architecture-diagram-with-mirrord.png)
 
 
-If you would like to learn more about how the mirrord-agent in the above architecture works, go check out the reference here /mirrord/docs/reference/architecture/#mirrord-agent.
+If you would like to learn more about how the mirrord-agent in the above architecture works, go check out the reference here /mirrord/docs/reference/architecture#mirrord-agent.
 
 We can now be sure that mirrord is working properly. 
 
@@ -255,7 +255,7 @@ The error states that the application is not able to connect to the Redis servic
 
 ## Installing mirrord
 
-Install the mirrord CLI tool and run Guestbook with the required Kubernetes context. Follow the installation guide for mirrord here /mirrord/docs/overview/quick-start/#installation.
+Install the mirrord CLI tool and run Guestbook with the required Kubernetes context. Follow the installation guide for mirrord here /mirrord/docs/getting-started/quick-start#installation.
 
 
 ## Run the guestbook application with Node.js and mirrord in the CLI

--- a/guides/how-to-debug-a-php-microservice.md
+++ b/guides/how-to-debug-a-php-microservice.md
@@ -118,7 +118,7 @@ The microservice needs access to the “redis” service hosted on the cluster. 
 
 2. Installing mirrord
 
-Install the mirrord CLI tool and run Guestbook with the required Kubernetes context. Follow the installation guide for mirrord [here](https://metalbear.com/mirrord/docs/overview/quick-start/#installation) .
+Install the mirrord CLI tool and run Guestbook with the required Kubernetes context. Follow the installation guide for mirrord [here](https://metalbear.com/mirrord/docs/getting-started/quick-start#installation) .
 
 3. Run the Guestbook application with php and mirrord in the CLI
 

--- a/guides/how-to-debug-a-python-microservice.md
+++ b/guides/how-to-debug-a-python-microservice.md
@@ -89,7 +89,7 @@ This run is expected to fail in most setups because local execution does not hav
 
 ### 2) Install mirrord
 
-Install mirrord by following the [quick start installation steps](https://metalbear.com/mirrord/docs/overview/quick-start/#installation).
+Install mirrord by following the [quick start installation steps](https://metalbear.com/mirrord/docs/getting-started/quick-start#installation).
 
 ### 3) Run the application with mirrord
 
@@ -136,7 +136,7 @@ Click the mirrord icon in the VS Code status bar and choose **Select active conf
 
 ![Select active mirrord config in VS Code](how-to-debug-a-python-miscroservice/using-mirrord-with-visual-studio-extension.png)
 
-If you expect multiple replicas and need advanced traffic behavior, check [mirrord for Teams](https://metalbear.com/mirrord/docs/overview/teams/).
+If you expect multiple replicas and need advanced traffic behavior, check [mirrord for Teams](https://metalbear.com/mirrord/docs/getting-started/what-is-mirrord).
 
 ### 3) Run and debug without mirrord first
 

--- a/guides/how-to-debug-a-ruby-microservice.md
+++ b/guides/how-to-debug-a-ruby-microservice.md
@@ -164,7 +164,7 @@ Let’s update the new config file created and opened in the editor. The configu
 }
 ```
 
-If you want to mirror traffic from a multipod deployment, you can learn more about mirrord for teams [/mirrord/docs/overview/teams/](https://metalbear.com/mirrord/docs/overview/teams/) which provides this feature. Right now we only have one pod in this deployment and mirrord’s OSS features should work perfectly for us.
+If you want to mirror traffic from a multipod deployment, you can learn more about mirrord for teams [/mirrord/docs/overview/teams/](https://metalbear.com/mirrord/docs/getting-started/what-is-mirrord) which provides this feature. Right now we only have one pod in this deployment and mirrord’s OSS features should work perfectly for us.
 
 2. **How to run the application with and without mirrord in the RubyMine IDE?**
 
@@ -205,7 +205,7 @@ Now that we can run the application, let’s understand our setup with the mirro
 
 ![alt text](how-to-debug-a-ruby-microservice/screenshot-2024-12-18-at-15-04-22-1.png)
 
-If you would like to learn more about how the mirrord-agent in the above architecture works, go check out the reference here [/mirrord/docs/reference/architecture/#mirrord-agent](https://metalbear.com/mirrord/docs/reference/architecture/#mirrord-agent).
+If you would like to learn more about how the mirrord-agent in the above architecture works, go check out the reference here [/mirrord/docs/reference/architecture/#mirrord-agent](https://metalbear.com/mirrord/docs/reference/architecture#mirrord-agent).
 
 We can now be sure that mirrord is working properly.
 
@@ -244,7 +244,7 @@ The microservice needs access to the “redis” service hosted on the cluster. 
 
 2. **Installing mirrord**
 
-Install the mirrord CLI tool and run Guestbook with the required Kubernetes context. Follow the installation guide for mirrord here [/mirrord/docs/overview/quick-start/#installation](https://metalbear.com/mirrord/docs/overview/quick-start/#installation) and run the below command.
+Install the mirrord CLI tool and run Guestbook with the required Kubernetes context. Follow the installation guide for mirrord here [/mirrord/docs/overview/quick-start/#installation](https://metalbear.com/mirrord/docs/getting-started/quick-start#installation) and run the below command.
 
 3. **Run the Guestbook application with ruby and mirrord in the CLI**
 

--- a/guides/how-to-debug-kafka-consumers.md
+++ b/guides/how-to-debug-kafka-consumers.md
@@ -2,7 +2,7 @@
 
 In this guide, we’ll cover how to debug Kafka consumer applications running in a Kubernetes environment using mirrord. You’ll learn how to set up mirrord and use it to effectively debug Kafka consumers without the traditional overhead of rebuilding and redeploying your application.
 
-**Tip**: mirrord is a development tool which makes developing cloud applications significantly easier. If you're not familiar, we recommend checking out the [getting started guide](https://metalbear.com/mirrord/docs/overview/quick-start/) first!
+**Tip**: mirrord is a development tool which makes developing cloud applications significantly easier. If you're not familiar, we recommend checking out the [getting started guide](https://metalbear.com/mirrord/docs/getting-started/quick-start) first!
 
 Debugging distributed applications, especially those that use messaging systems like Apache Kafka, can be challenging. These systems often span multiple services and depend on asynchronous communication patterns. Traditional debugging approaches can fall short when trying to trace issues across these complex systems.
 
@@ -70,7 +70,7 @@ Install the mirrord CLI:
 brew install metalbear-co/mirrord/mirrord
 ```
 
-For alternative installation methods, please follow the [quick start guide](https://metalbear.com/mirrord/docs/overview/quick-start/).
+For alternative installation methods, please follow the [quick start guide](https://metalbear.com/mirrord/docs/getting-started/quick-start).
 
 ## Installing mirrord operator
 
@@ -201,7 +201,7 @@ Now that we know how to access the producer, let’s dive into two effective app
 
 ### Approach 1: Simple Debugging with copy_target + scaledown (easier to execute)
 
-The simplest way to debug Kafka consumers is to ensure your local consumer is the only one receiving messages from the topic. mirrord’s copy_target feature with scale_down enabled accomplishes this. For detailed documentation, see [mirrord’s copy target documentation](https://metalbear.com/mirrord/docs/using-mirrord/copy-target/#replacing-a-whole-deployment-using-scale_down).
+The simplest way to debug Kafka consumers is to ensure your local consumer is the only one receiving messages from the topic. mirrord’s copy_target feature with scale_down enabled accomplishes this. For detailed documentation, see [mirrord’s copy target documentation](https://metalbear.com/mirrord/docs/using-mirrord/copy-target#replacing-a-whole-deployment-using-scale_down).
 
 ```json
 {
@@ -256,7 +256,7 @@ When you run this command, you can use the producer to send messages which will 
 
 ### Approach 2: Queue Splitting for non-disruptive debugging
 
-Queue splitting is a powerful feature in mirrord that allows both your local application and the remote application to receive the same messages. This is particularly useful when you want to debug without disrupting the existing remote consumers. For detailed documentation on queue splitting, visit [https://metalbear.com/mirrord/docs/using-mirrord/queue-splitting/](https://metalbear.com/mirrord/docs/using-mirrord/queue-splitting/).
+Queue splitting is a powerful feature in mirrord that allows both your local application and the remote application to receive the same messages. This is particularly useful when you want to debug without disrupting the existing remote consumers. For detailed documentation on queue splitting, visit [https://metalbear.com/mirrord/docs/sharing-the-cluster/queue-splitting](https://metalbear.com/mirrord/docs/sharing-the-cluster/queue-splitting).
 
 #### How queue splitting works
 
@@ -282,7 +282,7 @@ In case of multiple debug consumers, a new temporary mirrord topic and mirrord-c
 
 mirrord allows multiple debug consumers to run simultaneously. Each developer can run their own local consumer, and all will receive copies of the same messages. The mirrord operator also ensures that each local debug consumer gets a complete copy of the message stream, without any competition between them or with the production consumers.
 
-**Tip:** This means your entire team can debug the same Kafka consumer application simultaneously without interfering with each other or with other traffic to the staging cluster! This team collaboration capability is a feature of [mirrord for Teams](https://metalbear.com/mirrord/docs/overview/teams/).
+**Tip:** This means your entire team can debug the same Kafka consumer application simultaneously without interfering with each other or with other traffic to the staging cluster! This team collaboration capability is a feature of [mirrord for Teams](https://metalbear.com/mirrord/docs/getting-started/what-is-mirrord).
 
 #### Configuration for queue splitting
 
@@ -389,7 +389,7 @@ Similarly multiple debug consumers can consume these messages without disrupting
 
 ![mirrord Exec Queue Splitting 2](how-to-debug-kafka-consumers/terminal-multiple.png)
 
-Here, each instance creates its own mirrord-copy pod and receives the same messages, demonstrating how multiple developers can debug simultaneously. Notice in the second screenshot how multiple debug consumers are actively receiving messages in parallel. This collaborative debugging is made possible by [mirrord for Teams](https://metalbear.com/mirrord/docs/overview/teams/), which enables concurrent use of mirrord on the same environment.
+Here, each instance creates its own mirrord-copy pod and receives the same messages, demonstrating how multiple developers can debug simultaneously. Notice in the second screenshot how multiple debug consumers are actively receiving messages in parallel. This collaborative debugging is made possible by [mirrord for Teams](https://metalbear.com/mirrord/docs/getting-started/what-is-mirrord), which enables concurrent use of mirrord on the same environment.
 
 ## Debugging with mirrord vs. other debugging techniques
 
@@ -399,10 +399,10 @@ mirrord distinguishes itself by eliminating the need for repeated building and d
 
 In this guide, we’ve explored how to use mirrord to debug Kafka consumer applications in Kubernetes. We’ve seen two powerful approaches:
 
-1. **Queue splitting** allows you to debug without disrupting existing consumers by duplicating messages. Learn more about this feature in the [queue splitting documentation](https://metalbear.com/mirrord/docs/using-mirrord/queue-splitting/).
+1. **Queue splitting** allows you to debug without disrupting existing consumers by duplicating messages. Learn more about this feature in the [queue splitting documentation](https://metalbear.com/mirrord/docs/sharing-the-cluster/queue-splitting).
 
-2. **Copy target with scale down** gives your local application exclusive access to Kafka messages. Learn more in the [copy target documentation](https://metalbear.com/mirrord/docs/using-mirrord/copy-target/#replacing-a-whole-deployment-using-scale_down).
+2. **Copy target with scale down** gives your local application exclusive access to Kafka messages. Learn more in the [copy target documentation](https://metalbear.com/mirrord/docs/using-mirrord/copy-target#replacing-a-whole-deployment-using-scale_down).
 
-By leveraging mirrord, you can significantly improve your productivity when working with Kafka consumer applications and streamline your debugging workflow. For teams working together on Kafka applications, [mirrord for Teams](https://metalbear.com/mirrord/docs/overview/teams/) provides additional collaborative features that enable multiple developers to debug simultaneously.
+By leveraging mirrord, you can significantly improve your productivity when working with Kafka consumer applications and streamline your debugging workflow. For teams working together on Kafka applications, [mirrord for Teams](https://metalbear.com/mirrord/docs/getting-started/what-is-mirrord) provides additional collaborative features that enable multiple developers to debug simultaneously.
 
-Curious to try it out? Give mirrord a go and see how it works for you. Got questions? Visit the [mirrord documentation](https://metalbear.com/mirrord/docs/) or join the community [Slack](https://metalbear.com/slack) channel!
+Curious to try it out? Give mirrord a go and see how it works for you. Got questions? Visit the [mirrord documentation](https://metalbear.com/mirrord/docs) or join the community [Slack](https://metalbear.com/slack) channel!

--- a/guides/how-to-debug-sqs-consumers.md
+++ b/guides/how-to-debug-sqs-consumers.md
@@ -2,7 +2,7 @@
 
 In this guide, we’ll cover how to debug SQS consumer applications running in a Kubernetes environment using mirrord. You’ll learn how to set up mirrord and use it to effectively debug SQS consumers without the traditional overhead of rebuilding and redeploying your application.
 
-**Tip**: mirrord is a development tool which makes developing cloud applications significantly easier. If you're not familiar, we recommend checking out the [getting started guide](https://metalbear.com/mirrord/docs/overview/quick-start/) first!
+**Tip**: mirrord is a development tool which makes developing cloud applications significantly easier. If you're not familiar, we recommend checking out the [getting started guide](https://metalbear.com/mirrord/docs/getting-started/quick-start) first!
 
 Debugging distributed applications, especially those that use messaging systems like Amazon SQS, can be challenging. These systems often span multiple services and depend on asynchronous communication patterns. Traditional debugging approaches can fall short when trying to trace issues across these complex systems.
 
@@ -70,7 +70,7 @@ Install the mirrord CLI:
 brew install metalbear-co/mirrord/mirrord
 ```
 
-For alternative installation methods, please follow the [quick start guide](https://metalbear.com/mirrord/docs/overview/quick-start/).
+For alternative installation methods, please follow the [quick start guide](https://metalbear.com/mirrord/docs/getting-started/quick-start).
 
 ## Installing mirrord operator
 
@@ -219,7 +219,7 @@ Now that we know how to access the producer, let’s dive into two effective app
 
 ### Approach 1: Simple Debugging with copy_target + scaledown (easier to execute)
 
-The simplest way to debug SQS consumers is to ensure your local consumer is the only one receiving messages from the queue. mirrord’s copy_target feature with scale_down enabled accomplishes this. For detailed documentation, see [mirrord’s copy target documentation](https://metalbear.com/mirrord/docs/using-mirrord/copy-target/#replacing-a-whole-deployment-using-scale_down).
+The simplest way to debug SQS consumers is to ensure your local consumer is the only one receiving messages from the queue. mirrord’s copy_target feature with scale_down enabled accomplishes this. For detailed documentation, see [mirrord’s copy target documentation](https://metalbear.com/mirrord/docs/using-mirrord/copy-target#replacing-a-whole-deployment-using-scale_down).
 
 ```json
 {
@@ -271,7 +271,7 @@ When you run this command, you can use the producer to send messages which will 
 
 ### Approach 2: Queue Splitting for non-disruptive debugging
 
-Queue splitting is a powerful feature in mirrord that allows both your local application and the remote application to receive the same messages. This is particularly useful when you want to debug without disrupting the existing remote consumers. For detailed documentation on queue splitting, visit https://metalbear.com/mirrord/docs/using-mirrord/queue-splitting/.
+Queue splitting is a powerful feature in mirrord that allows both your local application and the remote application to receive the same messages. This is particularly useful when you want to debug without disrupting the existing remote consumers. For detailed documentation on queue splitting, visit https://metalbear.com/mirrord/docs/sharing-the-cluster/queue-splitting.
 
 #### How queue splitting works
 
@@ -297,7 +297,7 @@ In case of multiple debug consumers, a new temporary mirrord queue and mirrord-c
 
 mirrord allows multiple debug consumers to run simultaneously. Each developer can run their own local consumer, and all will receive copies of the same messages. The mirrord operator also ensures that each local debug consumer gets a complete copy of the message stream, without any competition between them or with the production consumers.
 
-**Tip**: This means your entire team can debug the same SQS consumer application simultaneously without interfering with each other or with production traffic! This team collaboration capability is a feature of [mirrord for Teams](https://metalbear.com/mirrord/docs/overview/teams/).
+**Tip**: This means your entire team can debug the same SQS consumer application simultaneously without interfering with each other or with production traffic! This team collaboration capability is a feature of [mirrord for Teams](https://metalbear.com/mirrord/docs/getting-started/what-is-mirrord).
 
 #### Configuration for queue splitting
 
@@ -393,7 +393,7 @@ You’ll see that both the consumer and the copy Pod are available ensuring that
 
 Similarly multiple debug consumers can consume these messages without disrupting the original consumer by creating more copy Pods and temporary mirrord queues as required.
 
-Here, each instance creates its own mirrord-copy pod and receives the same messages, demonstrating how multiple developers can debug simultaneously. Notice in the second screenshot how multiple debug consumers are actively receiving messages in parallel. This collaborative debugging is made possible by [mirrord for Teams](https://metalbear.com/mirrord/docs/overview/teams/), which enables concurrent use of mirrord on the same environment.
+Here, each instance creates its own mirrord-copy pod and receives the same messages, demonstrating how multiple developers can debug simultaneously. Notice in the second screenshot how multiple debug consumers are actively receiving messages in parallel. This collaborative debugging is made possible by [mirrord for Teams](https://metalbear.com/mirrord/docs/getting-started/what-is-mirrord), which enables concurrent use of mirrord on the same environment.
 
 ## Debugging with mirrord vs. other techniques
 
@@ -403,10 +403,10 @@ mirrord distinguishes itself by eliminating the need for repeated building and d
 
 In this guide, we’ve explored how to use mirrord to debug SQS consumer applications in Kubernetes. We’ve seen two powerful approaches:
 
-1. **Queue splitting** allows you to debug without disrupting existing consumers by duplicating messages. Learn more about this feature in the [queue splitting documentation](https://metalbear.com/mirrord/docs/using-mirrord/queue-splitting/).
+1. **Queue splitting** allows you to debug without disrupting existing consumers by duplicating messages. Learn more about this feature in the [queue splitting documentation](https://metalbear.com/mirrord/docs/sharing-the-cluster/queue-splitting).
 
-1. **Copy target with scale down** gives your local application exclusive access to SQS messages. Learn more in the [copy target documentation](https://metalbear.com/mirrord/docs/using-mirrord/copy-target/#replacing-a-whole-deployment-using-scale_down).
+1. **Copy target with scale down** gives your local application exclusive access to SQS messages. Learn more in the [copy target documentation](https://metalbear.com/mirrord/docs/using-mirrord/copy-target#replacing-a-whole-deployment-using-scale_down).
 
-By leveraging mirrord, you can significantly improve your productivity when working with SQS consumer applications and streamline your debugging workflow. For teams working together on SQS applications, [mirrord for Teams](https://metalbear.com/mirrord/docs/overview/teams/) provides additional collaborative features that enable multiple developers to debug simultaneously.
+By leveraging mirrord, you can significantly improve your productivity when working with SQS consumer applications and streamline your debugging workflow. For teams working together on SQS applications, [mirrord for Teams](https://metalbear.com/mirrord/docs/getting-started/what-is-mirrord) provides additional collaborative features that enable multiple developers to debug simultaneously.
 
-Curious to try it out? Give mirrord a go and see how it works for you. Got questions? Visit the [mirrord documentation](https://metalbear.com/mirrord/docs/) or join the community [Slack](https://metalbear.com/slack) channel!
+Curious to try it out? Give mirrord a go and see how it works for you. Got questions? Visit the [mirrord documentation](https://metalbear.com/mirrord/docs) or join the community [Slack](https://metalbear.com/slack) channel!

--- a/guides/running-ai-agents-with-mirrord.md
+++ b/guides/running-ai-agents-with-mirrord.md
@@ -13,7 +13,7 @@ In this guide, we'll cover how to set up an AI coding agent to test its own chan
 ## Prerequisites
 
 - A Kubernetes cluster with your services running (staging or dev)
-- [mirrord CLI installed](https://metalbear.com/mirrord/docs/installing-mirrord/cli)
+- [mirrord CLI installed](https://metalbear.com/mirrord/docs/getting-started/installing-mirrord/cli)
 - An existing E2E test suite that covers your critical happy paths (Playwright, Cypress, Jest, pytest, bash scripts, or any test runner)
 - An AI coding agent that can execute shell commands (Claude Code, Cursor, Codex)
 
@@ -44,7 +44,7 @@ Create a mirrord config for each service an agent might work on. If you already 
 }
 ```
 
-**Tip:** You can auto-generate configs for every service using the [mirrord skills package](https://github.com/metalbear-co/skills) for Claude Code, or the meta-prompt in [Using mirrord with AI Agents](https://metalbear.com/mirrord/docs/using-mirrord-with-ai) for any tool.
+**Tip:** You can auto-generate configs for every service using the [mirrord skills package](https://github.com/metalbear-co/skills) for Claude Code, or the meta-prompt in [Using mirrord with AI Agents](https://metalbear.com/mirrord/docs/use-cases/using-mirrord-with-ai) for any tool.
 
 ## Step 2: Write AGENTS.md for autonomous operation
 
@@ -212,5 +212,5 @@ For agents that need to write to the database without affecting shared staging d
 
 - [How to Test AI-Generated Code with mirrord](testing-ai-generated-code.md): test AI-generated code against your Kubernetes cluster step by step
 - [How to Set Up AI Tools with mirrord](setting-up-mirrord-for-ai-tools.md): per-tool config for Cursor, Claude Code, Copilot, and Codex
-- [Using mirrord with AI Agents](https://metalbear.com/mirrord/docs/using-mirrord-with-ai): auto-generate mirrord configs and AGENTS.md for your repo
+- [Using mirrord with AI Agents](https://metalbear.com/mirrord/docs/use-cases/using-mirrord-with-ai): auto-generate mirrord configs and AGENTS.md for your repo
 - [Sharing the Cluster](https://metalbear.com/mirrord/docs/sharing-the-cluster/overview): manage concurrent agent sessions with mirrord for Teams

--- a/guides/setting-up-mirrord-for-ai-tools.md
+++ b/guides/setting-up-mirrord-for-ai-tools.md
@@ -37,7 +37,7 @@ Before configuring any AI tool, create a mirrord config at `.mirrord/mirrord.jso
 
 For repos with multiple services, create one config per service: `.mirrord/mirrord-<service>.json`.
 
-**Tip:** You can auto-generate configs and agent instructions for your entire repo using the [mirrord skills package](https://github.com/metalbear-co/skills) for Claude Code, or the meta-prompt in [Using mirrord with AI Agents](https://metalbear.com/mirrord/docs/using-mirrord-with-ai) for any tool. The sections below show what to set up manually if you prefer.
+**Tip:** You can auto-generate configs and agent instructions for your entire repo using the [mirrord skills package](https://github.com/metalbear-co/skills) for Claude Code, or the meta-prompt in [Using mirrord with AI Agents](https://metalbear.com/mirrord/docs/use-cases/using-mirrord-with-ai) for any tool. The sections below show what to set up manually if you prefer.
 
 ## Claude Code
 
@@ -203,7 +203,7 @@ mirrord configs are in .mirrord/, one per service.
 
 ## Using the meta-prompt for any tool
 
-Instead of writing configs manually, you can paste the meta-prompt from [Using mirrord with AI Agents](https://metalbear.com/mirrord/docs/using-mirrord-with-ai) into any AI tool. It will:
+Instead of writing configs manually, you can paste the meta-prompt from [Using mirrord with AI Agents](https://metalbear.com/mirrord/docs/use-cases/using-mirrord-with-ai) into any AI tool. It will:
 
 1. Scan your repo to discover services
 2. Ask you which deployments to target
@@ -247,4 +247,4 @@ If the agent skips the mirrord step, strengthen the language in your instruction
 
 - [How to Test AI-Generated Code with mirrord](testing-ai-generated-code.md): test AI-generated code against your Kubernetes cluster step by step
 - [Autonomous AI Workflows with mirrord](running-ai-agents-with-mirrord.md): the full agent loop with E2E guardrails and AGENTS.md setup
-- [Using mirrord with AI Agents](https://metalbear.com/mirrord/docs/using-mirrord-with-ai): the meta-prompt and detailed setup reference
+- [Using mirrord with AI Agents](https://metalbear.com/mirrord/docs/use-cases/using-mirrord-with-ai): the meta-prompt and detailed setup reference

--- a/guides/testing-ai-generated-code.md
+++ b/guides/testing-ai-generated-code.md
@@ -11,7 +11,7 @@ In this guide, we'll cover how to test AI-generated code against your Kubernetes
 ## Prerequisites
 
 - A Kubernetes cluster with your services running (staging or dev)
-- [mirrord CLI installed](https://metalbear.com/mirrord/docs/installing-mirrord/cli)
+- [mirrord CLI installed](https://metalbear.com/mirrord/docs/getting-started/installing-mirrord/cli)
 - An AI coding tool (Claude Code, Cursor, Copilot, Codex)
 
 ## Step 1: Create a mirrord config
@@ -108,4 +108,4 @@ The request reaches your local code, but when your code queries the database or 
 
 - [Autonomous AI Workflows with mirrord](running-ai-agents-with-mirrord.md): the full agent loop with E2E guardrails and AGENTS.md setup
 - [How to Set Up AI Tools with mirrord](setting-up-mirrord-for-ai-tools.md): per-tool config for Cursor, Claude Code, Copilot, and Codex
-- [Using mirrord with AI Agents](https://metalbear.com/mirrord/docs/using-mirrord-with-ai): auto-generate mirrord configs and AGENTS.md for your repo
+- [Using mirrord with AI Agents](https://metalbear.com/mirrord/docs/use-cases/using-mirrord-with-ai): auto-generate mirrord configs and AGENTS.md for your repo


### PR DESCRIPTION
Guide pages linked to old docs URLs that 301-redirect (overview/quick-start → getting-started/quick-start, overview/teams → getting-started/what-is-mirrord#mirrord-for-teams, using-mirrord/queue-splitting → sharing-the-cluster/queue-splitting, installing-mirrord/cli → getting-started/installing-mirrord/cli, + trailing-slash strips). Rewrote to canonical paths (query/fragment preserved). 14 files. (42DM audit — internal 3xx.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)