### PR TITLE
Add support for Redis with `location: remote`

### DIFF
--- a/docs/managing-mirrord/operator.md
+++ b/docs/managing-mirrord/operator.md
@@ -102,6 +102,7 @@ DB branch pods pull a database image matching the engine. These are the defaults
 | MySQL | `docker.io/library/mysql:{version}` | `operator.mysqlBranchConfig` - `dbPod.image` |
 | MongoDB | `docker.io/library/mongo:{version}` | `operator.mongodbBranchConfig` - `dbPod.image` |
 | MSSQL | `mcr.microsoft.com/mssql/server:{version}` | `operator.mssqlBranchConfig` - `dbPod.image` |
+| Redis | `docker.io/library/redis:{version}` | `operator.redisBranchConfig` - `dbPod.image` |
 
 ##### Copying images
 

--- a/docs/reference/feature-matrix.md
+++ b/docs/reference/feature-matrix.md
@@ -17,7 +17,7 @@ Support levels vary by platform. The table below shows the current status for ea
   |                 | **[MongoDB](../sharing-the-cluster/db-branching.md)**           | `Alpha`       | `Alpha`         | Planned    |
   |                 | **[MySQL](../sharing-the-cluster/db-branching.md)**             | `Alpha`       | `Alpha`         | Planned    |
   |                 | **[MSSQL](../sharing-the-cluster/db-branching.md)**             | `Alpha`       | `Alpha`         | Planned    |
-  |                 | **[Redis](../sharing-the-cluster/db-branching.md#local-redis)**             | Planned     | Planned       | Planned |
+  |                 | **[Redis](../sharing-the-cluster/db-branching.md)** (both local and remote) | `Alpha`       | `Alpha`         | Planned    |
   | **[Queue Splitting](../sharing-the-cluster/queue-splitting.md)** | **[SQS](../sharing-the-cluster/queue-splitting.md#enable-sqs-splitting-in-the-helm-chart)**               | `Alpha`       | `Alpha`         | Planned    |
   |                 | **[Kafka](../sharing-the-cluster/queue-splitting.md#enable-kafka-splitting-in-the-helm-chart)**             | `Alpha`       | Planned       | Planned    |
   |                 | **Temporal**          | Planned     | Planned       | Planned |

--- a/docs/sharing-the-cluster/db-branching-advanced-config.md
+++ b/docs/sharing-the-cluster/db-branching-advanced-config.md
@@ -20,7 +20,7 @@ These settings give additional flexibility in how mirrord handles database branc
     "db_branches": [
       {
         "id": "users-mysql-db",            // Optional
-        "type": "mysql",                    // Available options [mysql|pg|mssql|mongodb]
+        "type": "mysql",                    // Available options [mysql|pg|mssql|mongodb|redis]
         "version": "8.0",
         "name": "users-database-name",      // Optional
         "ttl_secs": 60,                     // Optional, mutually exclusive with `ttl_mins`
@@ -352,6 +352,35 @@ All collections are copied, but the `users` collection includes only documents f
 ```
 
 Only the `users` collection is created, containing documents for alice and bob. All other collections are not created. This is useful when you only need a subset of reference data and your application handles the rest through migrations.
+
+## Redis Copy Modes
+
+Redis copy modes apply only to **remote** Redis branches. A local Redis branch always starts empty. Redis supports two modes:
+
+1. ### Empty Database
+
+`"mode": "empty"` Starts a fresh, empty Redis instance. This is the default value when the `copy` attribute is not specified.
+
+2. ### Complete Database
+
+`"mode": "all"` Copies keys from the source Redis instance into the branch.
+
+By default `"all"` copies the entire keyspace. To copy only a subset, add `patterns` - a list of [`SCAN MATCH`](https://redis.io/docs/latest/commands/scan/) glob patterns. Only keys matching at least one pattern are copied.
+
+```json
+{
+  "copy": {
+    "mode": "all",
+    "patterns": ["user:*", "session:*"]
+  }
+}
+```
+
+In this example, only keys prefixed with `user:` or `session:` are copied; everything else is left out of the branch.
+
+{% hint style="info" %}
+Redis has no schema, so there is no `"schema"` copy mode - only `"empty"` and `"all"` are available. Filtering is done by key pattern rather than by SQL query.
+{% endhint %}
 
 ## IAM Authentication
 

--- a/docs/sharing-the-cluster/db-branching.md
+++ b/docs/sharing-the-cluster/db-branching.md
@@ -15,7 +15,7 @@ This feature is available to users on the Team and Enterprise pricing plans.
 {% endhint %}
 
 The `db_branches` feature in mirrord lets developers spin up an isolated DB branch that mirrors the remote DB, while running safely in isolation. This allows schema changes, migrations, and experiments without impacting teammates or shared environments.
-Currently, the feature is limited to **MySQL, PostgreSQL, MSSQL, MongoDB** databases for remote usage, and **Redis** database for local development.
+Currently, the feature is limited to **MySQL, PostgreSQL, MSSQL, MongoDB, and Redis** databases for remote usage, and **Redis** database for local development.
 
 **When is this useful?**
 
@@ -40,7 +40,8 @@ Before you start, make sure you have:
   - PostgreSQL: Operator `3.131.0`, mirrord CLI `3.175.0` and operator Helm chart `1.40.2` with `operator.pgBranching` value set to `true`.
   - MSSQL: Operator `3.150.0`, mirrord CLI `3.195.0` and operator Helm chart `1.57.0` with `operator.mssqlBranching` value set to `true`.
   - MongoDB: Operator `3.137.0`, mirrord CLI `3.183.0` and operator Helm chart `1.44.0` with `operator.mongoBranching` value set to `true`.
-  - Redis: mirrord CLI `3.180.0` (no operator or chart version requirements, since Redis is supported only via a local DB branch).
+  - Redis (remote): Operator `3.168.0`, mirrord CLI `3.217.0` and operator Helm chart `3.168.0` with `operator.redisBranching` value set to `true`.
+  - Redis (local): mirrord CLI `3.180.0` (no operator or chart version requirements, since a local branch runs entirely on your machine).
 2. Your local application is using environment variables or Kubernetes Secrets to store DB connection strings or individual connection parameters.  
 3. mirrord installed and working.  
 
@@ -74,11 +75,12 @@ Developers define branches in their `mirrord.json`:
 ### Key Fields
 
 1. `id`: When reused, mirrord reattaches to the same branch as long as the time-to-live (TTL) has not expired. This allows multiple sessions to share the same database branch. To prevent accidental reuse of another user's branch, it is recommended to assign a unique value (for example, a UUID) as the identifier. (The `id` field is not used for local Redis instances and has no effect on database selection or reuse)
-2. `location`: Supported values are `remote` and `local`. The default is `remote`. `remote` applies only when the `type` field is set to `mysql`, `pg`, `mssql`, or `mongodb`, while `local` applies only when `type` is set to `redis`.
+2. `location`: Supported values are `remote` and `local`. The default is `remote`. For `mysql`, `pg`, `mssql`, and `mongodb`, only `remote` is supported. `redis` supports both: `remote` provisions a branch in the cluster like the other engines, while `local` spawns a Redis instance on your own machine.
 3. `type`: Supported values are `"mysql"`, `"pg"`, `"mssql"`, `"mongodb"`, and `"redis"`.
 4. `version`: Database engine version.
 5. `name`: Remote database name to clone, the override URL uses `name` so the connection URL looks like .../dbname.
 If name is ommited, the override URL just points to the database server; the application must select the DB manually in that case.
+For Redis, `name` is the database **index** Redis uses to select a logical database rather than a name, so it must be a valid non-negative number. If omitted, it defaults to index `0`.
 6. `ttl_secs` / `ttl_mins`: Override for branch time-to-live (TTL), expressed in seconds or minutes. The two fields are mutually exclusive — set whichever is more convenient. The default is 5 minutes.
 7. `connection`: Describes how to locate the source database connection details. Supports a full connection URL or individual connection parameters. See [Advanced Configuration](./db-branching-advanced-config.md#connection-modes) for details.
 8. `copy.mode`: Allows developers to control how the database is cloned when creating a branch, see [Advanced Configuration](./db-branching-advanced-config.md)
@@ -122,7 +124,7 @@ mirrord can spin up a local Redis instance, automatically redirecting your app's
     "db_branches": [
       {
         "type": "redis",
-        "location": "local",                     // "local" spawns Redis, "remote" is no-op (default)
+        "location": "local",                     // "remote" (default) or "local"
         "connection": {
           // Use "host" if your app reads Redis as host:port (e.g. REDIS_ADDR=redis:6379)
           // Use "url" if your app reads a full Redis URL (e.g. REDIS_URL=redis://user:pass@redis:6379/0)


### PR DESCRIPTION
Documentation for INT-437.

When reviewing, please pay special attention to the expected minimum versions where this feature will be usable as they aren't necessarily released yet.