### PR TITLE
Document mirrord preview start --force flag

### DIFF
--- a/docs/use-cases/preview-environments-in-ci.md
+++ b/docs/use-cases/preview-environments-in-ci.md
@@ -2,7 +2,7 @@
 title: Preview Environments in CI
 description: How to automate preview environments in your CI pipeline with PR-based keys and header propagation
 date: 2026-02-23T00:00:00.000Z
-lastmod: 2026-06-15T00:00:00.000Z
+lastmod: 2026-02-23T00:00:00.000Z
 draft: false
 toc: true
 tags:
@@ -122,17 +122,6 @@ mirrord preview start \
   -i "ghcr.io/org/my-app:preview-pr-123-abc1234" \
   -k "pr-123" \
   --timeout 600
-```
-
-When re-running `preview start` for the same PR key (for example, after a manual retry or a workflow re-run), add `--force` to replace the existing session instead of failing with a duplicate-key error:
-
-```bash
-mirrord preview start \
-  -f mirrord-preview.json \
-  -i "ghcr.io/org/my-app:preview-pr-123-abc1234" \
-  -k "pr-123" \
-  --timeout 600 \
-  --force
 ```
 
 ## CI Workflow Best Practices

--- a/docs/use-cases/preview-environments-in-ci.md
+++ b/docs/use-cases/preview-environments-in-ci.md
@@ -2,7 +2,7 @@
 title: Preview Environments in CI
 description: How to automate preview environments in your CI pipeline with PR-based keys and header propagation
 date: 2026-02-23T00:00:00.000Z
-lastmod: 2026-02-23T00:00:00.000Z
+lastmod: 2026-06-15T00:00:00.000Z
 draft: false
 toc: true
 tags:
@@ -122,6 +122,17 @@ mirrord preview start \
   -i "ghcr.io/org/my-app:preview-pr-123-abc1234" \
   -k "pr-123" \
   --timeout 600
+```
+
+When re-running `preview start` for the same PR key (for example, after a manual retry or a workflow re-run), add `--force` to replace the existing session instead of failing with a duplicate-key error:
+
+```bash
+mirrord preview start \
+  -f mirrord-preview.json \
+  -i "ghcr.io/org/my-app:preview-pr-123-abc1234" \
+  -k "pr-123" \
+  --timeout 600 \
+  --force
 ```
 
 ## CI Workflow Best Practices

--- a/docs/use-cases/preview-environments.md
+++ b/docs/use-cases/preview-environments.md
@@ -54,7 +54,15 @@ Each Preview Environment is identified by an **environment key**. The key is use
 - Associate multiple preview pods into a single environment
 - Share access to the same environment with other developers
 
-If no key is provided, mirrord generates one automatically
+If no key is provided, mirrord generates one automatically.
+
+Reusing the same key is common (for example, `pr-123` in CI or a fixed name for a shared preview). If a preview session with that key and target already exists, `mirrord preview start` refuses to create another one. To replace it (for example, after changing the image), pass `--force`:
+
+```bash
+mirrord preview start -f <mirrord.json> -i <image> -k <key> --force
+```
+
+Alternatively, stop the existing session first with `mirrord preview stop -k <key>`, or choose a different key.
 
 ---
 
@@ -78,14 +86,6 @@ Example output:
 ```
 
 - If `-k` is omitted, mirrord generates a new key and prints it in the output.
-
-If a preview session with the same key and target already exists, `mirrord preview start` refuses to create another one. To replace it (for example, after changing the image), pass `--force`:
-
-```bash
-mirrord preview start -f <mirrord.json> -i <image> -k <key> --force
-```
-
-Alternatively, stop the existing session first with `mirrord preview stop -k <key>`, or choose a different key.
 
 ---
 

--- a/docs/use-cases/preview-environments.md
+++ b/docs/use-cases/preview-environments.md
@@ -56,13 +56,7 @@ Each Preview Environment is identified by an **environment key**. The key is use
 
 If no key is provided, mirrord generates one automatically.
 
-Reusing the same key is common (for example, `pr-123` in CI or a fixed name for a shared preview). If a preview session with that key and target already exists, `mirrord preview start` refuses to create another one. To replace it (for example, after changing the image), pass `--force`:
-
-```bash
-mirrord preview start -f <mirrord.json> -i <image> -k <key> --force
-```
-
-Alternatively, stop the existing session first with `mirrord preview stop -k <key>`, or choose a different key.
+Reusing the same key is common (for example, `pr-123` in CI or a fixed name for a shared preview). See **Replace** under Managing Preview Environments when starting again with an existing key.
 
 ---
 
@@ -98,6 +92,10 @@ mirrord preview status
 2. **Stop:** Manually remove a Preview Environment and its associated preview pods when it is no longer needed.
 ```bash
 mirrord preview stop --key <environment-key>
+```
+3. **Replace:** Re-run `mirrord preview start` with the same key and target using `--force` (for example, after changing the image):
+```bash
+mirrord preview start -f <mirrord.json> -i <image> -k <key> --force
 ```
 
 ### GitHub Action

--- a/docs/use-cases/preview-environments.md
+++ b/docs/use-cases/preview-environments.md
@@ -1,6 +1,6 @@
 ---
 title: Preview Environments
-lastmod: 2026-04-15T00:00:00.000Z
+lastmod: 2026-06-15T00:00:00.000Z
 description: Ephemeral, isolated environments connected to your cluster
 
 ---
@@ -78,6 +78,14 @@ Example output:
 ```
 
 - If `-k` is omitted, mirrord generates a new key and prints it in the output.
+
+If a preview session with the same key and target already exists, `mirrord preview start` refuses to create another one. To replace it (for example, after changing the image), pass `--force`:
+
+```bash
+mirrord preview start -f <mirrord.json> -i <image> -k <key> --force
+```
+
+Alternatively, stop the existing session first with `mirrord preview stop -k <key>`, or choose a different key.
 
 ---
 

--- a/docs/use-cases/preview-environments.md
+++ b/docs/use-cases/preview-environments.md
@@ -1,6 +1,6 @@
 ---
 title: Preview Environments
-lastmod: 2026-06-15T00:00:00.000Z
+lastmod: 2026-04-15T00:00:00.000Z
 description: Ephemeral, isolated environments connected to your cluster
 
 ---
@@ -54,9 +54,7 @@ Each Preview Environment is identified by an **environment key**. The key is use
 - Associate multiple preview pods into a single environment
 - Share access to the same environment with other developers
 
-If no key is provided, mirrord generates one automatically.
-
-Reusing the same key is common (for example, `pr-123` in CI or a fixed name for a shared preview). See **Replace** under Managing Preview Environments when starting again with an existing key.
+If no key is provided, mirrord generates one automatically
 
 ---
 


### PR DESCRIPTION
## Summary
- Document `--force` on the Preview Environments page for replacing an existing session with the same key and target



Made with [Cursor](https://cursor.com)