### PR TITLE
local ui: update docs for COR-1585 - running ui in background

### DIFF
--- a/docs/using-mirrord/incoming-traffic/debug-from-browser.md
+++ b/docs/using-mirrord/incoming-traffic/debug-from-browser.md
@@ -29,8 +29,8 @@ There are two ways to use it:
 
 For operator sessions, additionally:
 
-3. A recent mirrord CLI (the `ui` subcommand needs to exist).
-4. A kubeconfig pointing at a cluster running the [mirrord operator](../../managing-mirrord/operator.md). The operator must be a version that exposes session metadata (3.157.1 or newer).
+3. A recent version of mirrord CLI (`3.198.0` or newer).
+4. A kubeconfig pointing at a cluster running the [mirrord operator](../../managing-mirrord/operator.md). The operator must be a version that exposes session metadata (`3.157.1` or newer).
 
 ### Quick start with `mirrord ui`
 
@@ -40,11 +40,20 @@ Run the local UI daemon in a terminal:
 mirrord ui
 ```
 
-It binds to localhost, prints a URL, and opens it in your default browser:
+It binds to localhost, prints some details, and opens the UI in your default browser:
 
-```
-  mirrord session monitor
-    Web UI: http://127.0.0.1:59281?token=...
+```text
+* New mirrord session monitor started
+* Server PID:
+ -> ...
+
+* Web UI:
+ -> http://127.0.0.1:59281?token=...
+* API token:
+-> x-auth-token: ...
+
+* mirrord session monitor ready!
+  -> log file: ...
 ```
 
 The Web UI page does an automatic handshake with the extension (over Chrome's `externally_connectable` mechanism) and hands it the daemon's address and a one-shot token. You should see this confirmation:
@@ -134,6 +143,7 @@ Once joined or active, open Chrome DevTools → Network on a request that hits y
 * The extension stores its configuration per browser profile in `chrome.storage.local`, so quitting the popup, closing Chrome, and reopening keeps your join state. Closing `mirrord ui` doesn't wipe the join — it just means the popup can't refresh the session list. Re-run `mirrord ui` to get it back.
 * Use **Reset to Default** on the Manual tab to revert to whatever `mirrord exec` last pushed in.
 * Saving on Manual after a Sessions-tab join overwrites the joined rule. Use **Leave** on the live banner first if you want to switch cleanly.
+* The server runs in the background on your machine. To stop it, run: `mirrord ui stop`.
 
 ### What's next?
 

--- a/docs/using-mirrord/local-ui.md
+++ b/docs/using-mirrord/local-ui.md
@@ -16,40 +16,71 @@ tags: ["open source", "team", "enterprise"]
 
 ## What it shows
 
-- **Local sessions** — each `mirrord exec` you have running locally, with its target, port subscriptions, processes, mirrord version, and a live event stream (file ops, DNS, HTTP requests, outgoing connections).
-- **Operator sessions** — a roll-up of every active mirrord session in your cluster, grouped by session key, with target, owner, namespace, and HTTP filter. Useful for seeing what your teammates have running before you start your own session, and for picking a session to ride on from the [mirrord browser extension](incoming-traffic/debug-from-browser.md).
+- **Local sessions** - each `mirrord exec` you have running locally, with its target, port subscriptions, processes, mirrord version, and a live event stream (file ops, DNS, HTTP requests, outgoing connections).
+- **Operator sessions** - a roll-up of every active mirrord session in your cluster, grouped by session key, with target, owner, namespace, and HTTP filter. Useful for seeing what your teammates have running before you start your own session, and for picking a session to ride on from the [mirrord browser extension](incoming-traffic/debug-from-browser.md).
 
 The dashboard updates live over a WebSocket as sessions start and end.
 
 ## Prerequisites
 
-- A recent mirrord CLI. The subcommand is available on macOS and Linux.
+- A recent mirrord CLI (`3.198.0` or newer). The subcommand is available on macOS and Linux.
 - A working kubeconfig pointing at a cluster running the [mirrord operator](../managing-mirrord/operator.md), if you want to see operator sessions. Without an operator, the dashboard still works for your own local sessions.
 
-## Running it
+## Quick start
 
 ```bash
 mirrord ui
 ```
 
-The CLI starts an HTTP + WebSocket server bound to localhost, generates a one-shot auth token, prints the URL, and opens it in your default browser.
+The CLI starts an HTTP + WebSocket server bound to localhost, generates a one-shot auth token, prints some details, and opens it in your default browser.
 
-```
-  mirrord session monitor
-    Web UI: http://127.0.0.1:59281?token=...
+```text
+* New mirrord session monitor started
+* Server PID:
+ -> ...
+
+* Web UI:
+ -> http://127.0.0.1:59281?token=...
+* API token:
+-> x-auth-token: ...
+
+* mirrord session monitor ready!
+  -> log file: ...
 ```
 
 The token is required on every API request, so there's no need to expose the dashboard beyond your machine. Each invocation generates a fresh token.
 
-To pick a different port:
+The server runs in the background on your machine. The logs for the server will be printed to a temporary file in the default temporary directory, and its file path is printed when the server is started. To stop the server, run:
+
+```bash
+mirrord ui stop
+```
+
+### Options
+
+To pick a **different port**:
 
 ```bash
 mirrord ui --port 9000
 ```
 
+To **skip opening the browser** when running the command:
+
+```bash
+mirrord ui --no-browser
+```
+
+To open using a **different browser**:
+
+```bash
+BROWSER="firefox" mirrord ui
+```
+
 ## Authentication
 
-The token is high-entropy and is bound to the running `mirrord ui` process. The first request you make with `?token=...` sets a `mirrord_token` cookie scoped to that origin so subsequent requests don't need to keep the query parameter. Closing `mirrord ui` invalidates the token; the next run mints a new one.
+The token is high-entropy and is bound to the running `mirrord ui` process. The first request you make with `?token=...` sets a `mirrord_token` cookie scoped to that origin so subsequent requests don't need to keep the query parameter. When sending requests directly to the server, you can also set the token in the header `x-auth-token`.
+
+Stopping the server with `mirrord ui stop` invalidates the token; the next run mints a new one.
 
 ## Browser extension auto-configure
 
@@ -57,9 +88,10 @@ If you have the [mirrord browser extension](incoming-traffic/debug-from-browser.
 
 ## Troubleshooting
 
-- **"Failed to bind"** — another process is on the chosen port. Pass `--port <other>`.
-- **Empty operator sessions list** — your kubeconfig context isn't pointing at a cluster with the mirrord operator installed, or your user doesn't have permission to read `MirrordOperator.status`. The local sessions panel still works.
-- **Dashboard says "unauthorized"** — the token in the URL didn't match. Re-open the URL the CLI printed; don't reuse a URL from a previous run.
+- **"Failed to bind"** - another process is on the chosen port. Pass `--port <other>`.
+- **Empty operator sessions list** - your kubeconfig context isn't pointing at a cluster with the mirrord operator installed, or your user doesn't have permission to read `MirrordOperator.status`. The local sessions panel still works.
+- **Dashboard says "unauthorized"** - the token in the URL didn't match. Re-open the URL the CLI printed; don't reuse a URL from a previous run.
+- **"Another session monitor is already running"** - the server is already running. If it isn't behaving as you expect, trying stopping it with `mirrord ui stop` or by killing it manually using its process ID, and then restarting.
 
 ## What's next?
 


### PR DESCRIPTION
For more details, see the description of https://github.com/metalbear-co/mirrord/pull/4460.
Relevant Linear Issue: https://linear.app/metalbear/issue/COR-1585/change-mirrord-ui-to-run-as-background-process

Updates the pages for local UI and browser debugging to reflect that the UI server runs as a background task.

Skip COR-1586 (I used the wrong branch name for this PR and confused Linear, oops)