### PR TITLE
security: document cluster_id and cluster_name in operator telemetry fields

### DIFF
--- a/docs/managing-mirrord/security.md
+++ b/docs/managing-mirrord/security.md
@@ -54,6 +54,8 @@ mirrord for Teams is completely on-prem. The Operator communicates with MetalBea
 5. instance_id (generated on runtime per Operator pod)
 6. subscription_id (generated uuid)
 7. organization_id (generated uuid)
+8. cluster_id (the UID of the cluster's `default` namespace, used as a stable, anonymous per-cluster identifier)
+9. cluster_name (optional; only sent if you set the `operator.clusterName` Helm value to give the cluster a recognizable label)
 
 In the Enterprise offering, this communication can be disabled entirely.
 


### PR DESCRIPTION
The operator now reports two new fields in its telemetry (metalbear-co/operator#1918, metalbear-co/operator#1920):

- `cluster_id` — UID of the cluster's `default` namespace, a stable anonymous per-cluster identifier sent on all telemetry events.
- `cluster_name` — optional, only sent when the installer sets the `operator.clusterName` Helm value.

Adds both to the "What data does the mirrord Operator send to MetalBear cloud?" list in the security page.