### PR TITLE
Document Kubernetes version in Operator telemetry fields

### DIFF
--- a/docs/managing-mirrord/security.md
+++ b/docs/managing-mirrord/security.md
@@ -56,6 +56,7 @@ mirrord for Teams is completely on-prem. The Operator communicates with MetalBea
 7. organization_id (generated uuid)
 8. cluster_id (the UID of the cluster's `default` namespace, used as a stable, anonymous per-cluster identifier)
 9. cluster_name (optional; only sent if you set the `operator.clusterName` Helm value to give the cluster a recognizable label)
+10. kubernetes_version (the version of the Kubernetes cluster the Operator is running in)
 
 In the Enterprise offering, this communication can be disabled entirely.
 

--- a/docs/managing-mirrord/security.md
+++ b/docs/managing-mirrord/security.md
@@ -54,6 +54,8 @@ mirrord for Teams is completely on-prem. The Operator communicates with MetalBea
 5. instance_id (generated on runtime per Operator pod)
 6. subscription_id (generated uuid)
 7. organization_id (generated uuid)
+8. cluster_id (the UID of the cluster's `default` namespace, used as a stable, anonymous per-cluster identifier)
+9. cluster_name (optional; only sent if you set the `operator.clusterName` Helm value to give the cluster a recognizable label)
 
 In the Enterprise offering, this communication can be disabled entirely.
 


### PR DESCRIPTION
Adds `kubernetes_version` to the list of fields the mirrord Operator sends to MetalBear cloud, in the Security docs. This documents the recently-added cluster telemetry field alongside `cluster_id` and `cluster_name`.