### PR TITLE
Document jq filters for Kafka queue splitting (INT-167)

### DIFF
--- a/docs/sharing-the-cluster/queue-splitting.md
+++ b/docs/sharing-the-cluster/queue-splitting.md
@@ -64,12 +64,13 @@ Filter definition contains the following fields:
 * `queue_type` - `SQS`, `Kafka`, `RMQ`, `GCPPubSub`, `AzureServiceBus`, `RedisPubSub`, `Temporal`, or `BullMQ`
 * `message_filter` - mapping from message attribute (SQS, GCP Pub/Sub), header (Kafka, RabbitMQ), application property (Azure Service Bus), JSON field (Redis Pub/Sub, BullMQ), or task metadata (Temporal) name to a regex for its value.
   The local application will only see queue messages that have **all** of the specified entries matching.
-* `jq_filter` - supported for `SQS`, `GCPPubSub`, `AzureServiceBus`, `RedisPubSub`, `Temporal`, and `BullMQ` queue types.
+* `jq_filter` - supported for `SQS`, `Kafka`, `GCPPubSub`, `AzureServiceBus`, `RedisPubSub`, `Temporal`, and `BullMQ` queue types.
   * For **SQS**, it runs a jq program on the JSON representation of the SQS [`Message`](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_Message.html) object.
     For queues configured with `s3_event: "true"`, jq filters can also inspect `S3Metadata`.
     It is populated with user-defined S3 object metadata when the message is parsed as an S3 event
     and metadata is fetched successfully. `S3Metadata` follows the [AWS S3 user-defined metadata format](https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingMetadata.html#UserMetadata):
     a flat key-value map where keys are lowercase strings (without the `x-amz-meta-` prefix) and values are strings.
+  * For **Kafka**, it runs a jq program on a JSON representation of the record. See the [Kafka page](queue-splitting/kafka.md#setting-a-filter) for the document shape.
   * For **GCP Pub/Sub**, it runs a jq program on the JSON representation of the [`PubsubMessage`](https://cloud.google.com/pubsub/docs/reference/rest/v1/PubsubMessage) object.
   * For **Azure Service Bus**, the JSON object has `body`, `application_properties`, `message_id`, `content_type`, and `subject` fields.
   * For **Redis Pub/Sub**, it runs a jq program on the parsed JSON message payload.

--- a/docs/sharing-the-cluster/queue-splitting/kafka.md
+++ b/docs/sharing-the-cluster/queue-splitting/kafka.md
@@ -246,7 +246,9 @@ To produce the authentication tokens, the operator uses the default credentials 
 
 #### Setting a filter
 
-For the full filter reference (`queue_type`, `message_filter`, `jq_filter`), see the [overview](../queue-splitting.md#setting-a-filter-for-a-mirrord-run). Kafka uses `queue_type: Kafka` and supports `message_filter` on Kafka headers.
+For the full filter reference (`queue_type`, `message_filter`, `jq_filter`), see the [overview](../queue-splitting.md#setting-a-filter-for-a-mirrord-run). Kafka uses `queue_type: Kafka` and supports `message_filter` on Kafka headers and `jq_filter` on a JSON representation of the whole record.
+
+**Filtering on headers**
 
 ```json
 {
@@ -266,6 +268,43 @@ For the full filter reference (`queue_type`, `message_filter`, `jq_filter`), see
 ```
 
 In the example above, the local application will receive a subset of messages from the Kafka queue with ID `views-topic`. All received messages will have a Kafka header `baggage` containing `mirrord-session=alice`.
+
+**Filtering on message content with jq**
+
+`jq_filter` runs a jq program on a JSON document the operator builds for each record:
+
+* `topic` - the topic name.
+* `partition` - the partition number.
+* `offset` - the record offset.
+* `timestamp` - the record timestamp in milliseconds (present only when the record carries one).
+* `key` - the record key (absent when the record has no key).
+* `payload` - the record value (absent when the record has no value).
+* `headers` - an object mapping header names to their values (always present, possibly empty; a repeated header name keeps the last value).
+
+`key`, `payload`, and header values are UTF-8 strings, or base64-encoded when not valid UTF-8. A record matches if the jq program outputs `true`.
+
+This lets you route messages by fields inside the message body. For example, to receive only messages whose JSON payload has a `merchantId` of `2137` under `data`:
+
+```json
+{
+  "operator": true,
+  "target": "deployment/meme-app/container/consumer",
+  "feature": {
+    "split_queues": {
+      "views-topic": {
+        "queue_type": "Kafka",
+        "jq_filter": ".payload | fromjson | .data.merchantId == 2137"
+      }
+    }
+  }
+}
+```
+
+If both `message_filter` and `jq_filter` are specified for the same queue, both must match for a message to reach the local application. Records for which the jq program errors (for example, a non-JSON payload piped to `fromjson`) are treated as not matching and stay on the deployed application's path.
+
+{% hint style="warning" %}
+`jq_filter` for Kafka requires mirrord operator `3.183.0` or later and mirrord CLI `3.232.0` or later, and is only supported with the default `librdkafka` client. Sessions using the Java client (`mirrord.client_implementation: java`, required for Kafka Streams) fail with a clear error when a `jq_filter` is set.
+{% endhint %}
 
 #### FAQ
 


### PR DESCRIPTION
## What

Kafka queue splitting now supports `jq_filter` ([INT-167](https://linear.app/metalbear/issue/INT-167/support-jq-filter-for-kafka-as-well)):
- metalbear-co/mirrord#4501 (config + CLI)
- metalbear-co/operator#1943 (operator implementation)

## Changes

- **Overview page**: `jq_filter` is now listed as supported for `Kafka`, linking to the Kafka page for the document shape (following the Temporal precedent).
- **Kafka page**: the "Setting a filter" section now documents both filter kinds — the existing header example, plus a new jq section describing the JSON record document (`topic`, `partition`, `offset`, `timestamp`, `key`, `payload`, `headers`; UTF-8-else-base64 values), a payload-content filtering example, the both-must-match semantics, jq-error-means-no-match behavior, and a warning hint with the minimum versions and the librdkafka-only limitation (jq is not supported with `mirrord.client_implementation: java` / Kafka Streams).

## Notes for merging

- **Merge only after the feature ships** in an operator + CLI release (docs publish from main via GitBook).
- The version numbers in the hint (`operator 3.183.0`, `CLI 3.232.0`) assume the next regular releases — please correct them at release time if the actual versions differ.

🤖 Generated with [Claude Code](https://claude.com/claude-code)