### PR TITLE
Mark WSL page as deprecated now that Windows is natively supported

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -11,8 +11,8 @@
   * [CLI](installing-mirrord/cli.md)
   * [VS Code](installing-mirrord/vscode.md)
   * [JetBrains IDEs](installing-mirrord/intellij.md)
-  * [WSL](installing-mirrord/wsl.md)
   * [mirrord Operator](managing-mirrord/operator.md)
+  * [WSL (deprecated)](installing-mirrord/wsl.md)
 
 ## Use Cases
 

--- a/docs/installing-mirrord/README.md
+++ b/docs/installing-mirrord/README.md
@@ -9,7 +9,7 @@ mirrord can be installed and used in several ways depending on your development 
 - **[VS Code](vscode.md)** - Install the mirrord extension for Visual Studio Code and compatible editors (Cursor, Windsurf, etc.)
 - **[JetBrains IDEs](intellij.md)** - Install the mirrord plugin for JetBrains IDEs (IntelliJ, PyCharm, GoLand, etc.)
 
-Using IDE extensions on Windows? See our **[WSL setup guide](wsl.md)**.
+mirrord runs natively on Windows — no WSL needed. If you still prefer to use WSL, see our **[WSL setup guide](wsl.md)**.
 
 ## Local Requirements
 

--- a/docs/installing-mirrord/wsl.md
+++ b/docs/installing-mirrord/wsl.md
@@ -1,9 +1,13 @@
 ---
-title: WSL
+title: WSL (deprecated)
 description: Installing and using mirrord on Windows with WSL
 ---
 
-# WSL
+# WSL (deprecated)
+
+{% hint style="info" %}
+mirrord now runs natively on Windows — no WSL needed. See the [CLI](cli.md), [VS Code](vscode.md), and [JetBrains IDEs](intellij.md) installation guides. This page is kept for users who still prefer to run mirrord through WSL, or for the few JetBrains run configurations that don't support native Windows yet.
+{% endhint %}
 
 Another way to run mirrord on Windows is using the _Linux Subsystem for Windows_ (_WSL_). You’ll also need a Kubernetes cluster. If you don’t have one, you can set one up locally using [Docker Desktop](https://docs.docker.com/desktop/install/windows-install/). mirrord works with any Kubernetes cluster, be it remote or local.
 


### PR DESCRIPTION
Since mirrord now supports Windows natively (no WSL needed), this updates the docs accordingly:

- Moved the WSL page below the mirrord Operator entry in the sidebar
- Renamed the page to "WSL (deprecated)"
- Added an intro hint noting native Windows support, linking to the CLI/VS Code/JetBrains guides, and clarifying the page is kept for users who prefer WSL or for the JetBrains run configurations that don't support native Windows yet
- Updated the "Installing mirrord" page, which was still pointing Windows IDE users to the WSL guide

🤖 Generated with [Claude Code](https://claude.com/claude-code)