### PR TITLE
monitoring: update details for using OTEL log exporter in operator

### DIFF
--- a/docs/managing-mirrord/monitoring.md
+++ b/docs/managing-mirrord/monitoring.md
@@ -96,6 +96,12 @@ operator:
 The features under the "OpenTelemetry" heading require at least operator chart version 1.46.0.
 {% endhint %}
 
+OTEL logs and traces can be sent from the operator to a configured OTLP collector endpoint using an HTTP exporter.
+
+{% hint style="info" %}
+As of version `3.186.0`, both `operator.otelLogExportUrl` and `operator.otelTraceExportUrl` may reference values set in `operator.extraEnv`, as they are added to the manifest below `extraEnv`.
+{% endhint %}
+
 #### Exporting Logs
 
 To export logs from the operator to an endpoint, set `operator.otelLogExportUrl` to the URL in the Operator Helm chart values. You _must_ set this value to export logs. This value does not affect the logs which are printed by the operator to `stdout` and are always enabled.
@@ -107,6 +113,22 @@ Note that this log level is separate to that defined for logs controlled by `ope
 #### Exporting Traces
 
 To export traces from the operator to an endpoint, set `operator.otelTraceExportUrl` to the URL in the Operator Helm chart values. You _must_ set this value to export traces.
+
+#### Using the downward API
+
+As of version `3.186.0`, values set in `operator.extraEnv` can be map values as an alternative to key value pairs, enabling variables to use the [Kubernetes downward API](https://kubernetes.io/docs/concepts/workloads/pods/downward-api/). This means you can reference downward API values in `operator.otel*ExportUrl` variables, for example:
+
+```yaml
+# values.yaml
+operator:
+  extraEnv:
+    HOST_IP:
+      valueFrom:
+        fieldRef:
+          fieldPath: status.hostIP
+    OTLP_PORT: "4318"
+  otelLogExportUrl: "http://$(HOST_IP):$(OTLP_PORT)/v1/logs"
+```
 
 #### Context Propagation
 

--- a/docs/managing-mirrord/monitoring.md
+++ b/docs/managing-mirrord/monitoring.md
@@ -99,7 +99,7 @@ The features under the "OpenTelemetry" heading require at least operator chart v
 OTEL logs and traces can be sent from the operator to a configured OTLP collector endpoint using an HTTP exporter.
 
 {% hint style="info" %}
-As of version `3.186.0`, both `operator.otelLogExportUrl` and `operator.otelTraceExportUrl` may reference values set in `operator.extraEnv`, as they are added to the manifest below `extraEnv`.
+As of version `3.186.0`, both `operator.otelLogExportUrl` and `operator.otelTraceExportUrl` may reference environment variables set in operator.extraEnv using $(VAR_NAME) syntax.
 {% endhint %}
 
 #### Exporting Logs
@@ -116,7 +116,8 @@ To export traces from the operator to an endpoint, set `operator.otelTraceExport
 
 #### Using the downward API
 
-As of version `3.186.0`, values set in `operator.extraEnv` can be map values as an alternative to key value pairs, enabling variables to use the [Kubernetes downward API](https://kubernetes.io/docs/concepts/workloads/pods/downward-api/). This means you can reference downward API values in `operator.otel*ExportUrl` variables, for example:
+As of version `3.186.0`, entries in `operator.extraEnv` can take a full environment variable spec (`valueFrom`) instead of a plain string value. Any valid environment variable source works, not just the downward API: `valueFrom` with `secretKeyRef` or `configMapKeyRef` renders the same way.
+This means you can reference [Kubernetes downward API](https://kubernetes.io/docs/concepts/workloads/pods/downward-api/) values in `operator.otel*ExportUrl` variables, for example:
 
 ```yaml
 # values.yaml


### PR DESCRIPTION
Follows [this operator PR](https://github.com/metalbear-co/operator/pull/2013), and addresses [this charts issue](https://github.com/metalbear-co/charts/issues/381)/ [Linear issue](https://linear.app/metalbear/issue/COR-1652/update-extraenv-to-inject-downward-api-values)

### Changes

- Explicitly mention that OTLP exporter is HTTP (not gRPC)
- Note that endpoint URL vars can use values set in `operator.extraEnv`, as [recommended in this Datadog example](https://docs.datadoghq.com/opentelemetry/migrate/ddot_collector/?tab=customcollectorcomponents#configure-your-application)
- Give example using map value (see [k8s downward API docs](https://kubernetes.io/docs/concepts/workloads/pods/downward-api/))