### PR TITLE
ci: clarify OSS vs Enterprise plan for mirrord ci

### DIFF
--- a/docs/use-cases/mirrord-for-ci.md
+++ b/docs/use-cases/mirrord-for-ci.md
@@ -11,7 +11,6 @@ description: How to use mirrord in a CI environment with `mirrord ci` commands.
 tags:
   - beta
   - oss
-  - team
   - enterprise
 ---
 
@@ -20,6 +19,10 @@ tags:
 mirrord can be used to greatly speed up CI runs by enabling testing against a shared staging environment without interrupting it. With mirrord for CI, you're able to keep your staging environment working, while also running your batch of end-to-end and other automated tests. The local app runs in the context of the targeted app that's deployed in your staging cluster, so it gets access to traffic, files, and more, as if it's running in the cluster. This means there's no need to spin up a whole test environment for a CI run, then spin it down when it's done.
 
 ![How mirrord for CI works](../.gitbook/assets/mirrord-ci-diagram.png)
+
+{% hint style="info" %}
+mirrord ci works with the open-source version of mirrord, no plan required. Running it with the mirrord Operator requires the Enterprise plan.
+{% endhint %}
 
 While running regular `mirrord exec` can be made to work for this purpose, it requires some finagling to get right, such as wrapping `mirrord exec` in some other command that would start it as a background process. The `mirrord ci start` command is more appropriate for this use case, since it starts your app and mirrord as background processes, allowing you to then run tests while your app is running in the background and connected to the cluster.
 
@@ -34,21 +37,23 @@ The CI runner must be able to access the Kubernetes cluster where the service yo
 
 It's recommended that you create a Kubernetes [service account](https://kubernetes.io/docs/concepts/security/service-accounts/) for the CI runner.
 
-#### For mirrord for Teams users
+#### Using mirrord ci with the mirrord Operator
 
 {% hint style="info" %}
-This feature is available to users on the Enterprise pricing plan.
+This section only applies to Enterprise plan users. If you're using the open-source version of mirrord, skip ahead to [Starting a mirrord CI session](#starting-a-mirrord-ci-session).
 {% endhint %}
 
-To use mirrord ci with mirrord Operator, you'll need to generate a CI API key and store it as a **secret** environment variable. This will prevent your usage of mirrord in CI from expending your seats, which are counted using a machine-based ID.
+When the mirrord Operator is installed in the cluster, running mirrord ci requires a CI API key. Generating the key requires an Enterprise plan.
 
-You can get this key by running the command:
+You can get the key by running the command:
 
 ```sh
 mirrord ci api-key
 ```
 
 Copy it and save it as the **secret** environment variable `MIRRORD_CI_API_KEY` in your CI.
+
+Sessions started with a CI API key don't count towards your seats, so CI runs won't consume them.
 
 #### Starting a mirrord CI session
 

--- a/docs/use-cases/mirrord-for-ci.md
+++ b/docs/use-cases/mirrord-for-ci.md
@@ -11,6 +11,7 @@ description: How to use mirrord in a CI environment with `mirrord ci` commands.
 tags:
   - beta
   - oss
+  - team
   - enterprise
 ---
 
@@ -37,13 +38,13 @@ The CI runner must be able to access the Kubernetes cluster where the service yo
 
 It's recommended that you create a Kubernetes [service account](https://kubernetes.io/docs/concepts/security/service-accounts/) for the CI runner.
 
-#### Using mirrord ci with the mirrord Operator
+#### Using mirrord for CI on the Enterprise tier
 
 {% hint style="info" %}
 This section only applies to Enterprise plan users. If you're using the open-source version of mirrord, skip ahead to [Starting a mirrord CI session](#starting-a-mirrord-ci-session).
 {% endhint %}
 
-When the mirrord Operator is installed in the cluster, running mirrord ci requires a CI API key. Generating the key requires an Enterprise plan.
+When the mirrord Operator is installed in the cluster, `mirrord ci` commands require a CI API key. Generating the key requires an Enterprise plan.
 
 You can get the key by running the command:
 
@@ -53,7 +54,7 @@ mirrord ci api-key
 
 Copy it and save it as the **secret** environment variable `MIRRORD_CI_API_KEY` in your CI.
 
-Sessions started with a CI API key don't count towards your seats, so CI runs won't consume them.
+Without the key, every CI runner would register as a new user and take up a seat. Sessions started with a CI API key don't count towards your seats, so CI runs won't consume them.
 
 #### Starting a mirrord CI session
 

--- a/docs/use-cases/mirrord-for-ci.md
+++ b/docs/use-cases/mirrord-for-ci.md
@@ -19,11 +19,7 @@ tags:
 
 mirrord can be used to greatly speed up CI runs by enabling testing against a shared staging environment without interrupting it. With mirrord for CI, you're able to keep your staging environment working, while also running your batch of end-to-end and other automated tests. The local app runs in the context of the targeted app that's deployed in your staging cluster, so it gets access to traffic, files, and more, as if it's running in the cluster. This means there's no need to spin up a whole test environment for a CI run, then spin it down when it's done.
 
-![How mirrord for CI works](../.gitbook/assets/mirrord-ci-diagram.png)
-
-{% hint style="info" %}
-mirrord ci works with the open-source version of mirrord, no plan required. Running it with the mirrord Operator requires the Enterprise plan.
-{% endhint %}
+![How mirrord ci works](../.gitbook/assets/mirrord-ci-diagram.png)
 
 While running regular `mirrord exec` can be made to work for this purpose, it requires some finagling to get right, such as wrapping `mirrord exec` in some other command that would start it as a background process. The `mirrord ci start` command is more appropriate for this use case, since it starts your app and mirrord as background processes, allowing you to then run tests while your app is running in the background and connected to the cluster.
 
@@ -45,6 +41,7 @@ This section only applies to Enterprise plan users. If you're using the open-sou
 {% endhint %}
 
 When the mirrord Operator is installed in the cluster, `mirrord ci` commands require a CI API key. Generating the key requires an Enterprise plan.
+Without the key, every CI runner would register as a new user and take up a seat. Sessions started with a CI API key don't count towards your seats, so CI runs won't consume them.
 
 You can get the key by running the command:
 
@@ -53,8 +50,6 @@ mirrord ci api-key
 ```
 
 Copy it and save it as the **secret** environment variable `MIRRORD_CI_API_KEY` in your CI.
-
-Without the key, every CI runner would register as a new user and take up a seat. Sessions started with a CI API key don't count towards your seats, so CI runs won't consume them.
 
 #### Starting a mirrord CI session
 


### PR DESCRIPTION
The mirrord for ci page read as if `mirrord ci` was an enterprise only feature (quote: "This feature is available to users on the Enterprise pricing plan"). This PR helps make the phrasing tighter