### PR TITLE
Remove incorrect namespace from MirrordClusterPolicy example

### DIFF
--- a/docs/sharing-the-cluster/policies.md
+++ b/docs/sharing-the-cluster/policies.md
@@ -47,7 +47,6 @@ apiVersion: policies.mirrord.metalbear.co/v1alpha
 kind: MirrordClusterPolicy
 metadata:
   name: block-steal-without-filter
-  namespace: mirrord-operator
 spec:
   targetPath: "*"
   block:


### PR DESCRIPTION
## Summary
- Drop `namespace: mirrord-operator` from the `MirrordClusterPolicy` example in the policies docs.
- That CRD is cluster-scoped, so a namespace has no effect and misleads readers into thinking one is required.

## Test plan
- [ ] Confirm the example renders correctly on the policies page
- [ ] Spot-check that namespaced `MirrordPolicy` examples still include `namespace` where appropriate


Made with [Cursor](https://cursor.com)