### PR TITLE
docs: add Cilium BPF host routing workaround for missed ClusterIP traffic

### DIFF
--- a/docs/troubleshooting/common-issues.md
+++ b/docs/troubleshooting/common-issues.md
@@ -61,6 +61,19 @@ This can happen in some clusters using a service mesh when stealing incoming tra
 {"agent": {"flush_connections": false}}
 ```
 
+## Traffic sent to the target through a Service ClusterIP is not stolen or mirrored on clusters using Cilium
+
+When Cilium runs as a kube-proxy replacement with BPF host routing (the default when `bpf.hostLegacyRouting` is not set), it delivers Service ClusterIP traffic directly into the target pod's network namespace, skipping the netfilter hooks where the mirrord agent redirects traffic. Requests sent to the Service are then handled by the remote target, while traffic sent directly to the pod IP (for example via `kubectl port-forward`) is stolen as expected.
+
+To use mirrord with this Cilium setup, set `bpf.hostLegacyRouting=true` on the Cilium Helm release, which moves packet delivery back onto the host network stack:
+
+```bash
+helm upgrade cilium cilium/cilium --namespace kube-system --reuse-values --set bpf.hostLegacyRouting=true
+kubectl -n kube-system rollout restart daemonset cilium
+```
+
+See [this issue](https://github.com/metalbear-co/mirrord/issues/4672) for more details.
+
 ## My application is trying to read a file locally instead of from the cluster
 
 mirrord has a list of path patterns that are read locally by default regardless of the configured fs mode. You can override this behavior in the configuration.


### PR DESCRIPTION
Ref: metalbear-co/mirrord#4672