### PR TITLE
Set `includeAuthors` and `disabledLabels` for Greptile

### DIFF
--- a/.greptile/config.json
+++ b/.greptile/config.json
@@ -1,0 +1,3 @@
+{
+  "disabledLabels": ["no-greptile"]
+}

--- a/.greptile/config.json
+++ b/.greptile/config.json
@@ -1,3 +1,25 @@
 {
+  "includeAuthors": [
+    "0x00A5",
+    "adnazujolakisic",
+    "aris-cub",
+    "aviramha",
+    "cristeigabriela",
+    "DmitryDodzin",
+    "eyalb181",
+    "gememma",
+    "giIuis",
+    "hank-metalbear",
+    "iniw",
+    "itsamegraf",
+    "meowjesty",
+    "MintSoup",
+    "Razz4780",
+    "RinkiyaKeDad",
+    "skreborn",
+    "t4lz",
+    "trawler",
+    "vladrbg"
+  ],
   "disabledLabels": ["no-greptile"]
 }

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -22,7 +22,7 @@ mirrord is open source and we welcome contributions!
 
 Greptile may review pull requests automatically. Authors and maintainers can apply the `no-greptile` label when an
 automated review is not needed, such as for a typo-only or other trivial change. Opting out of reviews that are not
-useful helps keep usage within the included monthly review quota. If Greptile's input becomes useful later, remove the
-label and request a review explicitly.
+useful helps keep usage within the included monthly review quota. If Greptile's input becomes useful later, tag
+`@greptileai` in the pull request to request a review explicitly.
 
 For detailed build instructions and development setup, see the [CONTRIBUTING.md](https://github.com/metalbear-co/mirrord/blob/main/CONTRIBUTING.md) in the repository.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -18,4 +18,11 @@ mirrord is open source and we welcome contributions!
 3. Make your changes
 4. Submit a pull request
 
+## Greptile Reviews
+
+Greptile may review pull requests automatically. Authors and maintainers can apply the `no-greptile` label when an
+automated review is not needed, such as for a typo-only or other trivial change. Opting out of reviews that are not
+useful helps keep usage within the included monthly review quota. If Greptile's input becomes useful later, remove the
+label and request a review explicitly.
+
 For detailed build instructions and development setup, see the [CONTRIBUTING.md](https://github.com/metalbear-co/mirrord/blob/main/CONTRIBUTING.md) in the repository.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -20,7 +20,7 @@ mirrord is open source and we welcome contributions!
 
 ## Greptile Reviews
 
-Greptile may review pull requests automatically. Authors and maintainers can apply the `no-greptile` label when an
+Greptile may review pull requests automatically. Maintainers can apply the `no-greptile` label when an
 automated review is not needed, such as for a typo-only or other trivial change. Opting out of reviews that are not
 useful helps keep usage within the included monthly review quota. If Greptile's input becomes useful later, tag
 `@greptileai` in the pull request to request a review explicitly.


### PR DESCRIPTION
## Summary

- limit automatic Greptile reviews to 20 frequent contributors
- allow maintainers to suppress an automatic review with the `no-greptile` label
- document the opt-out label, monthly quota rationale, and explicit `@greptileai` request path in the contributor guide

## Why

Automatic reviews should cover frequent contributors whose regular work will use a monthly seat anyway, while occasional contributors and trivial changes should not allocate one by default. Authors outside the allowlist can still receive a Greptile review by tagging `@greptileai`.

The opt-out label also lets authors and maintainers skip Greptile when an automated review is not added.