### PR TITLE
docs: fix operator install namespace ownership error

### DIFF
--- a/docs/managing-mirrord/operator.md
+++ b/docs/managing-mirrord/operator.md
@@ -16,9 +16,9 @@ In the open-source version of mirrord, each session is standalone - mirrord inje
 
 The Operator solves this by acting as a centralized control plane:
 
-* **Better security** - Users no longer need permissions to create privileged pods. Only the Operator does. Permissions are managed through Kubernetes RBAC.
-* **Concurrent use** - The Operator coordinates multiple mirrord sessions on the same cluster, preventing conflicts.
-* **Advanced features** - Support for [policies](../sharing-the-cluster/policies.md), [profiles](../sharing-the-cluster/profiles.md), [queue splitting](../sharing-the-cluster/queue-splitting.md), [DB branching](../sharing-the-cluster/db-branching.md), and more.
+- **Better security** - Users no longer need permissions to create privileged pods. Only the Operator does. Permissions are managed through Kubernetes RBAC.
+- **Concurrent use** - The Operator coordinates multiple mirrord sessions on the same cluster, preventing conflicts.
+- **Advanced features** - Support for [policies](../sharing-the-cluster/policies.md), [profiles](../sharing-the-cluster/profiles.md), [queue splitting](../sharing-the-cluster/queue-splitting.md), [DB branching](../sharing-the-cluster/db-branching.md), and more.
 
 ![mirrord for Teams - Architecture](../.gitbook/assets/operator-architecture.svg)
 
@@ -46,19 +46,25 @@ The Operator authenticates to the mirrord cloud with a **cloud API key** and use
 
 Provide the key to the chart in one of three ways:
 
-**Kubernetes secret (recommended)** — create a secret in your cluster and reference it via `cloud.apiKey.keyRef`, so the key never lives in your `values.yaml`:
-
-```bash
-kubectl create secret generic mirrord-operator-cloud-api-key \
-  --namespace mirrord \
-  --from-literal=apiKey=<your API key>
-```
+**Kubernetes secret (recommended)** — reference a secret via `cloud.apiKey.keyRef`, so the key never lives in your `values.yaml`:
 
 ```yaml
 cloud:
   apiKey:
     keyRef: mirrord-operator-cloud-api-key
 ```
+
+This only points the chart at a secret name, it doesn't require the secret to exist yet. Install the chart first (this also creates the `mirrord` namespace), then create the secret in it:
+
+```bash
+helm install -f values.yaml mirrord-operator metalbear/mirrord-operator
+
+kubectl create secret generic mirrord-operator-cloud-api-key \
+  --namespace mirrord \
+  --from-literal=apiKey=<your API key>
+```
+
+The Operator pod will wait until the secret exists and start automatically once it's created, no restart needed. If you create the secret before installing instead, make sure the `mirrord` namespace already exists and is Helm-managed, otherwise `helm install` will fail to adopt it.
 
 **Google Secret Manager** — store the key in GSM and reference it via `cloud.apiKey.gsmRef`. The Operator reads it using Application Default Credentials (see `sa.gcpSa`):
 
@@ -99,19 +105,24 @@ license:
           -----END CERTIFICATE-----
 ```
 
-Alternatively, create a Kubernetes secret and reference it via `license.pemRef` in `values.yaml`:
+Alternatively, reference a Kubernetes secret via `license.pemRef` in `values.yaml`:
+
+```yaml
+license:
+  pemRef: mirrord-operator-license-pem
+```
+
+This only points the chart at a secret name, it doesn't require the secret to exist yet. Install the chart first (this also creates the `mirrord` namespace), then create the secret in it:
 
 ```bash
+helm install -f values.yaml mirrord-operator metalbear/mirrord-operator
+
 kubectl create secret generic mirrord-operator-license-pem \
   --namespace mirrord \
   --from-file=license.pem=/path/to/license.pem
 ```
 
-Then install:
-
-```bash
-helm install -f values.yaml mirrord-operator metalbear/mirrord-operator
-```
+The Operator pod will wait until the secret exists and start automatically once it's created, no restart needed. If you create the secret before installing instead, make sure the `mirrord` namespace already exists and is Helm-managed, otherwise `helm install` will fail to adopt it.
 
 For a fully self-hosted setup, see the [license server](license-server.md).
 
@@ -131,13 +142,24 @@ Set `license.key` to your key, then install:
 helm install -f values.yaml mirrord-operator metalbear/mirrord-operator
 ```
 
-Alternatively, create a Kubernetes secret with your license key and reference it via `license.keyRef` in `values.yaml`:
+Alternatively, reference a Kubernetes secret via `license.keyRef` in `values.yaml`:
+
+```yaml
+license:
+  keyRef: mirrord-operator-license
+```
+
+This only points the chart at a secret name, it doesn't require the secret to exist yet. Install the chart first (this also creates the `mirrord` namespace), then create the secret in it:
 
 ```bash
+helm install -f values.yaml mirrord-operator metalbear/mirrord-operator
+
 kubectl create secret generic mirrord-operator-license \
   --namespace mirrord \
   --from-literal=OPERATOR_LICENSE_KEY=<your license key>
 ```
+
+The Operator pod will wait until the secret exists and start automatically once it's created, no restart needed. If you create the secret before installing instead, make sure the `mirrord` namespace already exists and is Helm-managed, otherwise `helm install` will fail to adopt it.
 
 ## Using an Internal Registry (Optional)
 
@@ -147,28 +169,28 @@ Using an internal registry reduces startup time, ingress costs, and removes depe
 
 These images are only pulled when the corresponding feature is enabled:
 
-| Image                   | Default                                     | Tag              | Description                                                                                   | Override                                        |
-| ----------------------- | ------------------------------------------- | ---------------- | --------------------------------------------------------------------------------------------- | ----------------------------------------------- |
-| Kafka splitting sidecar | `ghcr.io/metalbear-co/operator-kafka-proxy` | Same as operator | JVM sidecar for Kafka splitting (only when `operator.kafkaSplittingSidecar.enabled` is true). | `operator.kafkaSplittingSidecar.image`          |
-| MSSQL tools             | `ghcr.io/metalbear-co/mssql-tools`          | `latest`         | Sidecar for MSSQL DB branching (provides `sqlcmd`, `sqlpackage`, `bcp`).                      | Env `MSSQL_TOOLS_IMAGE` via `operator.extraEnv` |
+| Image                   | Default                                     | Tag              | Description                                                                                   | Override                                                                  |
+| ----------------------- | ------------------------------------------- | ---------------- | --------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| Kafka splitting sidecar | `ghcr.io/metalbear-co/operator-kafka-proxy` | Same as operator | JVM sidecar for Kafka splitting (only when `operator.kafkaSplittingSidecar.enabled` is true). | `operator.kafkaSplittingSidecar.image`                                    |
+| MSSQL tools             | `ghcr.io/metalbear-co/mssql-tools`          | `latest`         | Sidecar for MSSQL DB branching (provides `sqlcmd`, `sqlpackage`, `bcp`).                      | Env `MSSQL_TOOLS_IMAGE` via `operator.extraEnv`                           |
 | Flyway                  | `flyway/flyway`                             | `12`             | Flyway migration runner for DB branching.                                                     | Per-branch `migrations.image`, or `dbPod.migrationImages.flyway.registry` |
 
 ### DB branching default database images
 
 DB branch pods pull a database image matching the engine. These are the defaults when no custom image is specified in the branch config:
 
-| Engine     | Default image                              | Override                                        |
-| ---------- | ------------------------------------------ | ----------------------------------------------- |
-| PostgreSQL | `docker.io/library/postgres:{version}`     | `operator.pgBranchConfig` - `dbPod.image`       |
-| MySQL      | `docker.io/library/mysql:{version}`        | `operator.mysqlBranchConfig` - `dbPod.image`    |
-| MariaDB    | `docker.io/library/mariadb:{version}`      | `operator.mariadbBranchConfig` - `dbPod.image`  |
-| MongoDB    | `docker.io/library/mongo:{version}`        | `operator.mongodbBranchConfig` - `dbPod.image`  |
-| MSSQL      | `mcr.microsoft.com/mssql/server:{version}` | `operator.mssqlBranchConfig` - `dbPod.image`    |
-| Redis      | `docker.io/library/redis:{version}`        | `operator.redisBranchConfig` - `dbPod.image`    |
-| DynamoDB   | `amazon/dynamodb-local:{version}`          | `operator.dynamodbBranchConfig` - `dbPod.image` |
-| ClickHouse | `docker.io/clickhouse/clickhouse-server:{version}` | `operator.clickhouseBranchConfig` - `dbPod.image` |
-| CockroachDB | `docker.io/cockroachdb/cockroach:{version}` | `operator.cockroachdbBranchConfig` - `dbPod.image` |
-| Spanner    | `gcr.io/cloud-spanner-emulator/emulator:{version}` | `operator.spannerBranchConfig` - `dbPod.image` |
+| Engine      | Default image                                      | Override                                           |
+| ----------- | -------------------------------------------------- | -------------------------------------------------- |
+| PostgreSQL  | `docker.io/library/postgres:{version}`             | `operator.pgBranchConfig` - `dbPod.image`          |
+| MySQL       | `docker.io/library/mysql:{version}`                | `operator.mysqlBranchConfig` - `dbPod.image`       |
+| MariaDB     | `docker.io/library/mariadb:{version}`              | `operator.mariadbBranchConfig` - `dbPod.image`     |
+| MongoDB     | `docker.io/library/mongo:{version}`                | `operator.mongodbBranchConfig` - `dbPod.image`     |
+| MSSQL       | `mcr.microsoft.com/mssql/server:{version}`         | `operator.mssqlBranchConfig` - `dbPod.image`       |
+| Redis       | `docker.io/library/redis:{version}`                | `operator.redisBranchConfig` - `dbPod.image`       |
+| DynamoDB    | `amazon/dynamodb-local:{version}`                  | `operator.dynamodbBranchConfig` - `dbPod.image`    |
+| ClickHouse  | `docker.io/clickhouse/clickhouse-server:{version}` | `operator.clickhouseBranchConfig` - `dbPod.image`  |
+| CockroachDB | `docker.io/cockroachdb/cockroach:{version}`        | `operator.cockroachdbBranchConfig` - `dbPod.image` |
+| Spanner     | `gcr.io/cloud-spanner-emulator/emulator:{version}` | `operator.spannerBranchConfig` - `dbPod.image`     |
 
 [Generic branches](../sharing-the-cluster/db-branching/generic.md) have no default image - the user supplies the full image reference per branch. Admins can restrict which images are allowed with the `allowedImages` glob list under `operator.genericBranchConfig` - `dbPod.allowedImages` (when absent, all images are allowed), and `imagePullSecrets` in the same config covers private registries.
 


### PR DESCRIPTION
## Summary
- Fixes a bug in the mirrord Operator install docs where following the steps as written causes `helm install` to fail with `Namespace "mirrord" ... exists and cannot be imported into the current release`.
- Root cause: the chart creates the `mirrord` namespace itself (`createNamespace: true` by default), but the docs had users manually create the namespace first (to store a secret in it) before running `helm install`, so Helm can't adopt the pre-existing, unmanaged namespace.
- Fix: reorder the steps for all three credential paths (cloud API key, air-gapped license cert, license key) so `helm install` runs first — creating the namespace — and the Kubernetes secret is created afterward. The Operator pod waits and starts automatically once the secret exists, no restart needed. Also calls out that setting `keyRef`/`pemRef` in `values.yaml` beforehand is just a local file edit with no cluster dependency.

## Test plan
- [ ] Docs-only change; verify rendered page reads correctly in GitBook preview