### PR TITLE
Update operator default CPU limit in scalability docs

### DIFF
--- a/docs/managing-mirrord/scalability.md
+++ b/docs/managing-mirrord/scalability.md
@@ -32,7 +32,7 @@ Unless overridden at install time, the operator uses the following resource defa
 
 | Resource | Request | Limit  |
 | -------- | ------- | ------ |
-| CPU      | 100m    | 200m   |
+| CPU      | 100m    | 500m   |
 | Memory   | 100Mi   | 200Mi  |
 
 {% hint style="info" %}


### PR DESCRIPTION
Keeps the default sizing table in sync with the Helm chart: the operator's default CPU limit is now `500m` (was `200m`). Requests are unchanged.