### PR TITLE
up: add details for setting context via arg or config file

### DIFF
--- a/docs/using-mirrord/multiple-concurrent-sessions.md
+++ b/docs/using-mirrord/multiple-concurrent-sessions.md
@@ -118,15 +118,49 @@ RabbitMQ isn't supported yet in `mirrord up`.
 Only messages containing the session key (`checkout-debug` in this case) are routed to your local session. All other messages continue to the deployed target.
 {% endhint %}
 
+### Context
+
+`mirrord up` allows you to specify which Kubernetes context to run services in. You can do this either with the `--context` flag, or by setting it in `context` in the config file.
+
+The following config file sets the `minikube` context for `user-auth-service` and `kind` context for `stage-user-dashboard-app` via the `common` field.
+
+```yaml
+common:
+  context: kind
+services:
+  user-auth-service:
+    context: minikube
+    run:
+      command: ["python", "-m", "http.server"]
+
+  stage-user-dashboard-app:
+    target:
+      path: pod/nginx
+    run:
+      command: ["node", "app.js"]
+```
+
+To override the context for every service in a run, use `mirrord up --context minikube`.
+
+#### Context precedence
+
+| common context | service context | `--context` | context used              |
+|----------------|-----------------|-------------|---------------------------|
+| any            | any             | set         | `--context`               |
+| any            | set             | unset       | service context           |
+| set            | unset           | unset       | common context            |
+| unset          | unset           | unset       | default (current context) |
+
 ### Config file (`mirrord-up.yaml`)
 
 #### `common`
-Common configuration options, applied to all defined services. Currently 3 options are supported:
+Common configuration options, applied to all defined services. Currently the following options are supported:
 - [`accept_invalid_certificates`](https://metalbear.com/mirrord/docs/config/options#root-accept_invalid_certificates)
 - [`operator`](https://metalbear.com/mirrord/docs/config/options#root-operator)
 - [`telemetry`](https://metalbear.com/mirrord/docs/config/options#root-telemetry)
+- [`context`](https://metalbear.com/mirrord/docs/config/options#root-kube_context)
 
-All 3 map directly to their `mirrord.json` counterparts.
+All fields map directly to their `mirrord.json` counterparts.
 
 #### `services`
 A map from service ids to a `ServiceConfig`. Each entry in this map defines and configures a mirrord process that will be run as part of the session.
@@ -199,6 +233,11 @@ run:
   command: ["node", "app.js"]
 ```
 
+##### `services.*.context`
+The name of the Kubernetes context to run services in. See [Context](#context) for precedence rules when used with `common.context`.
+
+The `--context` argument overrides this for every service being launched.
+
 ### Templating
 
 The `mirrord-up.yaml` configuration file is rendered with [Tera](https://keats.github.io/tera/docs/) (Jinja2-style syntax) before it is parsed. This lets you populate configuration values dynamically from the session key and from your shell environment.
@@ -268,6 +307,9 @@ Runs every service in the given mode, ignoring the `default_mode` set in the con
 
 ### `--key`
 Allows specifying a custom session key. When not supplied, the OS username is used.
+
+### `--context`
+Runs every service in the specified context, ignoring the `context` field(s) set in the config file. When omitted, each service uses the `context` in the config file. See [Context](#context) for precedence rules.
 
 ## `mirrord up init`
 

--- a/docs/using-mirrord/multiple-concurrent-sessions.md
+++ b/docs/using-mirrord/multiple-concurrent-sessions.md
@@ -122,7 +122,7 @@ Only messages containing the session key (`checkout-debug` in this case) are rou
 
 `mirrord up` allows you to specify which Kubernetes context to run services in. You can do this either with the `--context` flag, or by setting it in `context` in the config file.
 
-The following config file sets the `minikube` context for `user-auth-service` and `kind` context for `stage-user-dashboard-app` via the `common` field.
+The following config file sets the `kind` context for all services via `common` field, and overrides it to `minikube` for `user-auth-service`.
 
 ```yaml
 common:
@@ -234,7 +234,7 @@ run:
 ```
 
 ##### `services.*.context`
-The name of the Kubernetes context to run services in. See [Context](#context) for precedence rules when used with `common.context`.
+The name of the Kubernetes context to run this service in. See [Context](#context) for precedence rules when used with `common.context`.
 
 The `--context` argument overrides this for every service being launched.
 


### PR DESCRIPTION
mirrord PR: https://github.com/metalbear-co/mirrord/pull/4679

- Added a Context section under Configuration with a table showing precedence for various methods of setting context
- Added `context` under `common` config fields
- Added `services.*.context` config field
- Added `--context` under CLI args