### PR TITLE
Fix some missing target docs, and add label target.

### DIFF
--- a/docs/faq/general.md
+++ b/docs/faq/general.md
@@ -80,6 +80,11 @@ mirrord for Teams adds support for the following workloads:
 - CronJobs
 - StatefulSets
 
+mirrord for Teams also supports targeting:
+
+* Services
+* Labels
+
 In mirrord for Teams, mirrord will always target all pods when a workload with multiple pods is used as the remote target.
 
 Both in mirrord OSS and mirrord for Teams, if you don't name any specific container to be targeted, mirrord will pick the first container from the pod spec. Some containers, like service mesh proxies, will be automatically ignored.
@@ -95,5 +100,3 @@ mirrord mirrors environmental inputs of your Kubernetes workload, such as enviro
 When you run your service locally with mirrord, your application starts from the same inputs as the in-cluster version. If your application’s startup logic fetches secrets from AWS and then caches them in memory, the local version will run that same logic and fetch the secrets again. mirrord’s job is to provide your local process with the same environment and the same access paths, not to copy running state from the remote process.
 
 If you prefer to avoid calling external secret providers during local development, you will need to mock or override that behavior within your application. mirrord does not intercept or alter application logic related to secret retrieval, and it does not supply cached in-memory data from remote pods.
-
-

--- a/docs/reference/targets.md
+++ b/docs/reference/targets.md
@@ -36,11 +36,18 @@ mirrord for Teams adds support for the following workloads:
 * CronJobs
 * StatefulSets
 * ReplicaSets
+
+mirrord for Teams also supports targeting:
+
 * Services
+* Labels
 
 In mirrord for Teams, mirrord will always target all pods when a workload with multiple pods is used as the remote target.
 
 When targeting a Service, mirrord resolves the Service to its backing pods via the Service's selector. Jobs and CronJobs require [`copy_target`](../using-mirrord/copy-target.md) to be enabled.
+
+When targeting Labels, mirrord will target all pods that match the label selector. At present, only basic features are supported
+for this target type, meaning it doesn't yet support copy, db branching, preview environments, or queue splitting.
 
 Both in mirrord OSS and mirrord for Teams, if you don't name any specific container to be targeted, mirrord will pick the first container from the pod spec. Some containers, like service mesh proxies, will be automatically ignored.
 

--- a/docs/sharing-the-cluster/policies.md
+++ b/docs/sharing-the-cluster/policies.md
@@ -186,7 +186,9 @@ The example above will enforce that the user selects either `my-profile-1` or `m
 
 By default, mirrord policies apply to all targets in the namespace or cluster. You can use a target path pattern (`.spec.targetPath`) and/or a [label selector](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#resources-that-support-set-based-requirements) (`.spec.selector`) in order to limit the targets to which a policy applies.
 
-The target path of a mirrord run is either `targetless` or has the form `<TARGET_TYPE>/<NAME>` followed by an optional `/container/<CONTAINER_NAME>`, where `<TARGET_TYPE>` is one of `deploy`, `pod`, `rollout` and `statefulset`.
+The target path of a mirrord run is either `targetless` or has the form `<TARGET_TYPE>/<NAME>` followed by an optional
+`/container/<CONTAINER_NAME>`, where `<TARGET_TYPE>` is one of `deploy`, `pod`, `rollout`, `statefulset`, `replicaset`, `job`,
+`cronjob`, `service`, or `label`.
 
 Examples for possible target paths:
 


### PR DESCRIPTION
- Issue: https://linear.app/metalbear/issue/COR-1671/support-one-local-session-with-multi-target-in-a-single-cluster
- Related PRs:
  - https://github.com/metalbear-co/mirrord/pull/4586
  - https://github.com/metalbear-co/operator/pull/2043

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>