### PR TITLE
Link agents.md and the rules-file ports from the AI docs

### DIFF
--- a/docs/using-mirrord-with-ai/README.md
+++ b/docs/using-mirrord-with-ai/README.md
@@ -14,3 +14,4 @@ Here are some ways you can connect mirrord to your AI coding workflow:
 
 - **[Agent skills for mirrord](./ai-skills-plugin.md)** - Install skills that give your AI assistant built-in mirrord expertise.
 - **[Configure AI Agents to Use mirrord](./the-meta-prompt.md)** - A prompt generator that creates project-specific `AGENTS.md` files and configurations automatically, saving hours of manual setup across multiple services.
+- **[metalbear.com/agents.md](https://metalbear.com/agents.md)** - A short operational reference written for agents rather than people: install commands, finding targets, running code through mirrord, configuration, and etiquette on a shared cluster. Point an agent at the URL directly when you want it to pick mirrord up without any repository setup.

--- a/docs/using-mirrord-with-ai/ai-skills-plugin.md
+++ b/docs/using-mirrord-with-ai/ai-skills-plugin.md
@@ -36,3 +36,7 @@ For the full list of skills, what each one covers, and example prompts, see <a h
 The mirrord skills are distributed as a plugin that you install into your AI coding assistant. Installation steps depend on your tool.
 
 Check the <a href="https://github.com/metalbear-co/skills/" target="_blank" rel="noopener noreferrer">mirrord skills repository</a> for the latest installation instructions...
+
+## Agents That Don't Support Agent Skills
+
+GitHub Copilot and Cline read repository rules files instead of Agent Skills. The skills repository ships drop-in equivalents carrying the same core content in its <a href="https://github.com/metalbear-co/skills/tree/main/ports" target="_blank" rel="noopener noreferrer">ports directory</a>: copy `ports/github-copilot/copilot-instructions.md` into your repository's `.github/` folder, or `ports/cline/.clinerules` into the repository root.


### PR DESCRIPTION
## Why

Two gaps in `using-mirrord-with-ai`, both found while checking whether per-tool pages (Claude Code / Cursor / Codex) were needed. They aren't — the meta-prompt page already covers agent configuration generically and better than three near-duplicate pages would. These are the real gaps:

1. **metalbear.com/agents.md is linked nowhere in the docs.** It's the canonical operational reference written for agents (install, targets, `mirrord exec`, config, shared-cluster etiquette), and it went live yesterday via metalbear.co#505.
2. **Nothing mentions the rules-file ports.** GitHub Copilot and Cline read repository rules files rather than Agent Skills; `metalbear-co/skills#53` added drop-in equivalents in `ports/` yesterday, and Copilot/Cline users currently have no path to them from the docs.

## What

- README: third bullet pointing at metalbear.com/agents.md, framed as the zero-setup option.
- Skills page: a short section covering agents that don't support Agent Skills, pointing at `ports/`.

Both link targets verified live (HTTP 200). Five added lines, no restructuring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)