### PR TITLE
FAQ: mirrord works with Teleport and Tailscale

### DIFF
--- a/docs/faq/general.md
+++ b/docs/faq/general.md
@@ -51,14 +51,6 @@ No, mirrord doesn't install anything on the cluster, nor does it have any persis
 
 If you have any restrictions for pulling external images inside your cluster, you have to allow pulling of ghcr.io/metalbear-co/mirrord image.
 
-## Does mirrord work with Teleport, Tailscale, or other secure cluster access tools?
-
-Yes, and there's nothing to configure.
-
-mirrord reaches your cluster entirely through the Kubernetes API, using the same kubeconfig `kubectl` uses. That covers everything it does: the [mirrord Operator](../managing-mirrord/operator.md) is exposed as a Kubernetes APIService, and the connection to the [mirrord agent](../reference/architecture.md#mirrord-agent) runs over Kubernetes port forwarding. mirrord never opens a network path of its own.
-
-If `kubectl` works through your access provider, mirrord works through it too. Customers run mirrord behind Teleport and Tailscale today.
-
 ## How does mirrord protect against disrupting my shared environment with my local code?
 
 - By letting you mirror traffic rather than intercept it, the stable version of the code can still run in the cluster and handle requests.

--- a/docs/faq/general.md
+++ b/docs/faq/general.md
@@ -55,7 +55,7 @@ If you have any restrictions for pulling external images inside your cluster, yo
 
 Yes, and there's nothing to configure.
 
-mirrord reaches your cluster entirely through the Kubernetes API, using the same kubeconfig `kubectl` uses. The connection between your local process and the [mirrord agent](../reference/architecture.md#mirrord-agent) runs over Kubernetes port forwarding on that same connection, so mirrord never opens a network path of its own.
+mirrord reaches your cluster entirely through the Kubernetes API, using the same kubeconfig `kubectl` uses. That covers everything it does: the [mirrord Operator](../managing-mirrord/operator.md) is exposed as a Kubernetes APIService, and the connection to the [mirrord agent](../reference/architecture.md#mirrord-agent) runs over Kubernetes port forwarding. mirrord never opens a network path of its own.
 
 If `kubectl` works through your access provider, mirrord works through it too. Customers run mirrord behind Teleport and Tailscale today.
 

--- a/docs/faq/general.md
+++ b/docs/faq/general.md
@@ -51,6 +51,14 @@ No, mirrord doesn't install anything on the cluster, nor does it have any persis
 
 If you have any restrictions for pulling external images inside your cluster, you have to allow pulling of ghcr.io/metalbear-co/mirrord image.
 
+## Does mirrord work with Teleport, Tailscale, or other secure cluster access tools?
+
+Yes, and there's nothing to configure.
+
+mirrord reaches your cluster entirely through the Kubernetes API, using the same kubeconfig `kubectl` uses. The connection between your local process and the [mirrord agent](../reference/architecture.md#mirrord-agent) runs over Kubernetes port forwarding on that same connection, so mirrord never opens a network path of its own.
+
+If `kubectl` works through your access provider, mirrord works through it too. Customers run mirrord behind Teleport and Tailscale today.
+
 ## How does mirrord protect against disrupting my shared environment with my local code?
 
 - By letting you mirror traffic rather than intercept it, the stable version of the code can still run in the cluster and handle requests.

--- a/docs/faq/limitations.md
+++ b/docs/faq/limitations.md
@@ -32,6 +32,14 @@ Yes, mirrord works exactly the same way with and without a service mesh installe
 
 Yes, mirrord works with OpenShift. However, OpenShift usually ships with a default security policy that doesn't let mirrord create pods. To fix this, you would need to tweak your `scc` settings - more information [here](https://docs.openshift.com/container-platform/3.11/admin_guide/manage_scc.html). If you'd rather keep the default security policies, we recommend trying out [mirrord for Teams](../managing-mirrord/operator.md).
 
+#### Does mirrord support Teleport, Tailscale, or other secure cluster access tools?
+
+Yes, and there's nothing to configure.
+
+mirrord reaches your cluster entirely through the Kubernetes API, using the same kubeconfig `kubectl` uses. That covers everything it does: the [mirrord Operator](../managing-mirrord/operator.md) is exposed as a Kubernetes APIService, and the connection to the [mirrord agent](../reference/architecture.md#mirrord-agent) runs over Kubernetes port forwarding. mirrord never opens a network path of its own.
+
+If `kubectl` works through your access provider, mirrord works through it too. Customers run mirrord behind Teleport and Tailscale today.
+
 #### Does mirrord support binaries that are statically compiled? (Linux)
 
 No, mirrord needs to be able to leverage dynamic linking in order to work. This means static binaries are not supported.


### PR DESCRIPTION
Adds one entry to the **Limitations** FAQ, next to the service mesh and OpenShift questions, which are the same shape: does mirrord survive a given piece of cluster infrastructure.

**Why.** Platform teams in regulated and on-prem environments reach their clusters through an access broker rather than a raw kubeconfig, and whether mirrord survives that layer comes up during evaluation. There is currently no mention of Teleport or Tailscale anywhere in the docs, so the question has no answer to point at.

**The answer is that there is nothing to configure.** mirrord reaches the cluster entirely through the Kubernetes API using the same kubeconfig `kubectl` uses. That holds for both paths: the Operator is exposed as a Kubernetes APIService, and per `reference/architecture.md` the layer exchanges events with the agent over Kubernetes port forwarding. mirrord never opens a network path of its own. Confirmed by customers running it behind both today.

Also worth having for search: "mirrord teleport" is the kind of query a platform engineer types into a search box or asks an agent, and we currently rank for nothing on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
