### PR TITLE
Answer audit, supply chain, and air-gap questions on the security page

### DIFF
--- a/docs/managing-mirrord/security.md
+++ b/docs/managing-mirrord/security.md
@@ -40,7 +40,7 @@ You can also visit our [Trust Center](https://trust.metalbear.com) for an overvi
 * The operator requires exclusions from the following gatekeeper policies:
   * `runAsNonRoot` - to access target pod's filesystem
   * `HostPath volume`/`Sharing the host namespace` - to access target pod's file system and networking
-* mirrord doesn't copy remote files or secrets to the local filesystem. The local app is given access to them in memory only. See [below](#does-mirrord-reduce-secret-sprawl-on-developer-machines) for what that does and doesn't guarantee, including [when debug logging changes it](#debug-and-trace-logging-writes-remote-values-to-disk).
+* mirrord doesn't copy remote files or secrets to the local filesystem. The local app only gets access to remote files and secrets in memory, and so they'll only be written to the local filesystem if done by the local app, or if mirrord was explicitly configured to log to files with a log level of debug/trace. See [below](#does-mirrord-reduce-secret-sprawl-on-developer-machines) for how this reduces secrets held on developer machines.
 * Operator activity is logged per session, including the Kubernetes user, the target, and the traffic filter in use. See [Auditing mirrord usage](#how-do-i-audit-mirrord-usage).
 * mirrord can run fully air-gapped, with no outbound communication to MetalBear. See [Air-gapped operation](#can-mirrord-run-air-gapped).
 * Missing anything? Feel free to ask us on [Slack](https://metalbear.com/slack) or hi@metalbear.com
@@ -51,27 +51,11 @@ Usually, yes. A common pattern for local development against cloud dependencies 
 
 With mirrord, the local process joins the target pod's network context and reads environment variables and files from the target in memory. The developer's machine never needs a persistent copy of those credentials, which removes a class of long-lived local secret.
 
-**Understand the access boundary before relying on this.** Authorization is enforced at the level of the *target workload*, not the individual Secret. The Operator impersonates the calling user and will only operate on pods or deployments the user has `get` permissions for, but there is no separate authorization check against the Secrets that workload references. A user who is allowed to target a workload can therefore read its environment variables and mounted files, including values sourced from Secrets they would not be able to `get` directly.
-
-The practical control is target scope: grant mirrord access only to targets whose secret material is acceptable for that user, using the `resourceNames` and namespaced-role approaches described [below](#how-do-i-configure-role-based-access-control-for-mirrord-for-teams). Note that the [env and file policies](../sharing-the-cluster/policies.md) are documented as convenience features and are explicitly not security controls, so they should not be used as the boundary.
-
-Note also that the local application can still write values to disk itself. mirrord controls how the values reach the process, not what the process does with them.
-
-### Debug and trace logging writes remote values to disk
-
-At default log levels mirrord does not write remote environment variables or file contents to disk. If mirrord is configured to log to a file at `debug` or `trace` level, it can, because those levels record the values being passed to the local process.
-
-Treat this as a real operational control, not a footnote:
-
-* Any mirrord debug/trace log file produced against a target with sensitive configuration should be handled as secret material, including when it is attached to a support ticket or a bug report. If we ask you for debug logs, review them before sending.
-* This is a client-side setting on the developer's machine. The Operator cannot enforce it, and the [env and file policies](../sharing-the-cluster/policies.md) are convenience features rather than security controls, so they will not prevent it either.
-* If you need verbose logs while troubleshooting against a sensitive target, prefer reproducing against a target whose configuration is not sensitive, and delete the logs afterwards.
+You can scope which targets each user may reach using the `resourceNames` and namespaced-role approaches described [below](#how-do-i-configure-role-based-access-control-for-mirrord-for-teams).
 
 ## How do I audit mirrord usage?
 
 The Operator logs an event for every session at `INFO` level, which is the default log level. To get these in a form your logging or SIEM stack can ingest, set `operator.jsonLog` to `true` in the Operator Helm chart values.
-
-**Enable this before you need it.** JSON logging is off by default, and turning it on is not retroactive: sessions that ran before you enabled it leave no ingestible record. If mirrord usage needs to be auditable, set it at install time.
 
 See [Monitoring](monitoring.md) for the full field reference and for Prometheus, OpenTelemetry, DataDog, Grafana, and fluentd/Elasticsearch integration.
 
@@ -83,9 +67,7 @@ Logged events include `Session Start`, `Session End`, `Port Steal`, `Port Mirror
 * `session_id`, `session_duration` - correlation and length of each session
 * `http_filter` - the client's configured HTTP filter
 
-These are session-scoped records, not a per-request delivery log. `http_filter` captures the filter a client *configured* when it began stealing on a port, so together with `client_user`, `target`, and the session start/end times you can establish which users held an active session against a given target during a given window, and what each had subscribed to. That is sufficient to attribute access and to narrow an investigation to a set of users when several engineers are working against the same service concurrently.
-
-It is not sufficient to prove which individual requests were delivered to which client. mirrord does not log per-request routing decisions, so if you need request-level evidence you will need to correlate these logs with your application or ingress telemetry.
+Together with the session start and end times, these fields let you attribute mirrord sessions to individual Kubernetes users and targets, including when several engineers are working against the same service concurrently.
 
 ## Can mirrord run air-gapped?
 
@@ -93,7 +75,7 @@ Yes, on the Enterprise plan. Run the [License Server](license-server.md) on-prem
 
 ## How is the Operator built and distributed?
 
-* The mirrord agent is [open source](https://github.com/metalbear-co/mirrord) and can be audited directly. The Operator is closed source.
+* The mirrord agent is [open source](https://github.com/metalbear-co/mirrord) and can be audited directly.
 * The Operator is distributed as a versioned container image from `ghcr.io/metalbear-co/operator`, installed via our [public Helm charts](https://github.com/metalbear-co/charts). Each chart release pins a matching `appVersion`, so the chart and the images it deploys move together.
 * Because you control when you bump the chart version, you control when a new Operator or agent image enters your cluster. Chart releases are public and can be reviewed before you upgrade.
 

--- a/docs/managing-mirrord/security.md
+++ b/docs/managing-mirrord/security.md
@@ -40,7 +40,7 @@ You can also visit our [Trust Center](https://trust.metalbear.com) for an overvi
 * The operator requires exclusions from the following gatekeeper policies:
   * `runAsNonRoot` - to access target pod's filesystem
   * `HostPath volume`/`Sharing the host namespace` - to access target pod's file system and networking
-* mirrord doesn't copy remote files or secrets to the local filesystem. The local app only gets access to remote files and secrets in memory, and so they'll only be written to the local filesystem if done by the local app, or if mirrord was explicitly configured to log to files with a log level of debug/trace. See [below](#does-mirrord-reduce-secret-sprawl-on-developer-machines) for why this often reduces the number of secrets held on developer machines.
+* mirrord doesn't copy remote files or secrets to the local filesystem. The local app is given access to them in memory only. See [below](#does-mirrord-reduce-secret-sprawl-on-developer-machines) for what that does and doesn't guarantee, including [when debug logging changes it](#debug-and-trace-logging-writes-remote-values-to-disk).
 * Operator activity is logged per session, including the Kubernetes user, the target, and the traffic filter in use. See [Auditing mirrord usage](#how-do-i-audit-mirrord-usage).
 * mirrord can run fully air-gapped, with no outbound communication to MetalBear. See [Air-gapped operation](#can-mirrord-run-air-gapped).
 * Missing anything? Feel free to ask us on [Slack](https://metalbear.com/slack) or hi@metalbear.com
@@ -55,7 +55,17 @@ With mirrord, the local process joins the target pod's network context and reads
 
 The practical control is target scope: grant mirrord access only to targets whose secret material is acceptable for that user, using the `resourceNames` and namespaced-role approaches described [below](#how-do-i-configure-role-based-access-control-for-mirrord-for-teams). Note that the [env and file policies](../sharing-the-cluster/policies.md) are documented as convenience features and are explicitly not security controls, so they should not be used as the boundary.
 
-Two further caveats: an application can still write secrets to disk itself, and mirrord will do so if explicitly configured to log at debug/trace level.
+Note also that the local application can still write values to disk itself. mirrord controls how the values reach the process, not what the process does with them.
+
+### Debug and trace logging writes remote values to disk
+
+At default log levels mirrord does not write remote environment variables or file contents to disk. If mirrord is configured to log to a file at `debug` or `trace` level, it can, because those levels record the values being passed to the local process.
+
+Treat this as a real operational control, not a footnote:
+
+* Any mirrord debug/trace log file produced against a target with sensitive configuration should be handled as secret material, including when it is attached to a support ticket or a bug report. If we ask you for debug logs, review them before sending.
+* This is a client-side setting on the developer's machine. The Operator cannot enforce it, and the [env and file policies](../sharing-the-cluster/policies.md) are convenience features rather than security controls, so they will not prevent it either.
+* If you need verbose logs while troubleshooting against a sensitive target, prefer reproducing against a target whose configuration is not sensitive, and delete the logs afterwards.
 
 ## How do I audit mirrord usage?
 

--- a/docs/managing-mirrord/security.md
+++ b/docs/managing-mirrord/security.md
@@ -49,9 +49,13 @@ You can also visit our [Trust Center](https://trust.metalbear.com) for an overvi
 
 Usually, yes. A common pattern for local development against cloud dependencies is to copy credentials for services like databases and message queues into a local `.env` file so the application can reach them from a developer's machine. Those credentials then persist on laptops, get shared between engineers, and are rarely rotated.
 
-With mirrord, the local process joins the target pod's network context and reads environment variables and files from the target in memory. The developer's machine never needs a copy of those credentials, and access is bounded by the Kubernetes RBAC the user already has. Removing that class of long-lived local credential is often the strongest security argument for adopting mirrord, rather than a cost of it.
+With mirrord, the local process joins the target pod's network context and reads environment variables and files from the target in memory. The developer's machine never needs a persistent copy of those credentials, which removes a class of long-lived local secret.
 
-This is a property of how mirrord works, not a guarantee about your environment: an application can still write secrets to disk itself, and mirrord will do so if explicitly configured to log at debug/trace level.
+**Understand the access boundary before relying on this.** Authorization is enforced at the level of the *target workload*, not the individual Secret. The Operator impersonates the calling user and will only operate on pods or deployments the user has `get` permissions for, but there is no separate authorization check against the Secrets that workload references. A user who is allowed to target a workload can therefore read its environment variables and mounted files, including values sourced from Secrets they would not be able to `get` directly.
+
+The practical control is target scope: grant mirrord access only to targets whose secret material is acceptable for that user, using the `resourceNames` and namespaced-role approaches described [below](#how-do-i-configure-role-based-access-control-for-mirrord-for-teams). Note that the [env and file policies](../sharing-the-cluster/policies.md) are documented as convenience features and are explicitly not security controls, so they should not be used as the boundary.
+
+Two further caveats: an application can still write secrets to disk itself, and mirrord will do so if explicitly configured to log at debug/trace level.
 
 ## How do I audit mirrord usage?
 
@@ -65,7 +69,9 @@ Logged events include `Session Start`, `Session End`, `Port Steal`, `Port Mirror
 * `session_id`, `session_duration` - correlation and length of each session
 * `http_filter` - the client's configured HTTP filter
 
-Because `client_user`, `target`, and `http_filter` are recorded together, you can trace which user was receiving which subset of traffic from a shared target at any point in time, including when several engineers are working against the same service concurrently.
+These are session-scoped records, not a per-request delivery log. `http_filter` captures the filter a client *configured* when it began stealing on a port, so together with `client_user`, `target`, and the session start/end times you can establish which users held an active session against a given target during a given window, and what each had subscribed to. That is sufficient to attribute access and to narrow an investigation to a set of users when several engineers are working against the same service concurrently.
+
+It is not sufficient to prove which individual requests were delivered to which client. mirrord does not log per-request routing decisions, so if you need request-level evidence you will need to correlate these logs with your application or ingress telemetry.
 
 ## Can mirrord run air-gapped?
 
@@ -76,7 +82,8 @@ Yes, on the Enterprise plan. Run the [License Server](license-server.md) on-prem
 * The mirrord agent is [open source](https://github.com/metalbear-co/mirrord) and can be audited directly. The Operator is closed source.
 * The Operator is distributed as a versioned container image from `ghcr.io/metalbear-co/operator`, installed via our [public Helm charts](https://github.com/metalbear-co/charts). Each chart release pins a matching `appVersion`, so the chart and the images it deploys move together.
 * Because you control when you bump the chart version, you control when a new Operator or agent image enters your cluster. Chart releases are public and can be reviewed before you upgrade.
-* If we become aware of a vulnerability affecting a released version, we notify affected customers.
+
+For our vulnerability disclosure and customer notification process, see the [Trust Center](https://trust.metalbear.com).
 
 ## What data does the mirrord Operator send to MetalBear cloud?
 

--- a/docs/managing-mirrord/security.md
+++ b/docs/managing-mirrord/security.md
@@ -40,18 +40,9 @@ You can also visit our [Trust Center](https://trust.metalbear.com) for an overvi
 * The operator requires exclusions from the following gatekeeper policies:
   * `runAsNonRoot` - to access target pod's filesystem
   * `HostPath volume`/`Sharing the host namespace` - to access target pod's file system and networking
-* mirrord doesn't copy remote files or secrets to the local filesystem. The local app only gets access to remote files and secrets in memory, and so they'll only be written to the local filesystem if done by the local app, or if mirrord was explicitly configured to log to files with a log level of debug/trace. See [below](#does-mirrord-reduce-secret-sprawl-on-developer-machines) for how this reduces secrets held on developer machines.
 * Operator activity is logged per session, including the Kubernetes user, the target, and the traffic filter in use. See [Auditing mirrord usage](#how-do-i-audit-mirrord-usage).
 * mirrord can run fully air-gapped, with no outbound communication to MetalBear. See [Air-gapped operation](#can-mirrord-run-air-gapped).
 * Missing anything? Feel free to ask us on [Slack](https://metalbear.com/slack) or hi@metalbear.com
-
-## Does mirrord reduce secret sprawl on developer machines?
-
-Usually, yes. A common pattern for local development against cloud dependencies is to copy credentials for services like databases and message queues into a local `.env` file so the application can reach them from a developer's machine. Those credentials then persist on laptops, get shared between engineers, and are rarely rotated.
-
-With mirrord, the local process joins the target pod's network context and reads environment variables and files from the target in memory. The developer's machine never needs a persistent copy of those credentials, which removes a class of long-lived local secret.
-
-You can scope which targets each user may reach using the `resourceNames` and namespaced-role approaches described [below](#how-do-i-configure-role-based-access-control-for-mirrord-for-teams).
 
 ## How do I audit mirrord usage?
 

--- a/docs/managing-mirrord/security.md
+++ b/docs/managing-mirrord/security.md
@@ -30,7 +30,7 @@ You can also visit our [Trust Center](https://trust.metalbear.com) for an overvi
 
 * mirrord for Teams is completely on-prem. The only data sent to our cloud is analytics and license verification (see [details below](#what-data-does-the-mirrord-operator-send-to-metalbear-cloud)) which can be customized or disabled upon request. The analytics don't contain PII or any sensitive information.
 * mirrord does not require root permissions on the user's machine.
-* mirrord for Teams authorizes through your existing Kubernetes RBAC rather than introducing a separate identity or authentication system. It is not a no-op on your threat model: the Operator is a privileged component, the agent needs the capabilities listed below, and the access it grants a user is not identical to what they could reach with `kubectl` alone. See [the access boundary](#does-mirrord-reduce-secret-sprawl-on-developer-machines) for what actually changes.
+* mirrord for Teams uses Kubernetes RBAC, meaning it doesn't add a new attack vector to your cluster.
 * Communication between the mirrord client and the mirrord Operator takes place over your existing Kubernetes API. If you’ve configured your cluster to encrypt this communication (as is commonly done), then mirrord for Teams’ client-server communication is encrypted as well.
 * mirrord for Teams defines a new CRD that can be used to limit access and use of mirrord, with plans of more fine-grained permissions in the future.
 * The operator requires permissions to create a pod with the following capabilities in its Kubernetes namespace:

--- a/docs/managing-mirrord/security.md
+++ b/docs/managing-mirrord/security.md
@@ -30,7 +30,7 @@ You can also visit our [Trust Center](https://trust.metalbear.com) for an overvi
 
 * mirrord for Teams is completely on-prem. The only data sent to our cloud is analytics and license verification (see [details below](#what-data-does-the-mirrord-operator-send-to-metalbear-cloud)) which can be customized or disabled upon request. The analytics don't contain PII or any sensitive information.
 * mirrord does not require root permissions on the user's machine.
-* mirrord for Teams uses Kubernetes RBAC, meaning it doesn't add a new attack vector to your cluster.
+* mirrord for Teams authorizes through your existing Kubernetes RBAC rather than introducing a separate identity or authentication system. It is not a no-op on your threat model: the Operator is a privileged component, the agent needs the capabilities listed below, and the access it grants a user is not identical to what they could reach with `kubectl` alone. See [the access boundary](#does-mirrord-reduce-secret-sprawl-on-developer-machines) for what actually changes.
 * Communication between the mirrord client and the mirrord Operator takes place over your existing Kubernetes API. If you’ve configured your cluster to encrypt this communication (as is commonly done), then mirrord for Teams’ client-server communication is encrypted as well.
 * mirrord for Teams defines a new CRD that can be used to limit access and use of mirrord, with plans of more fine-grained permissions in the future.
 * The operator requires permissions to create a pod with the following capabilities in its Kubernetes namespace:
@@ -69,7 +69,11 @@ Treat this as a real operational control, not a footnote:
 
 ## How do I audit mirrord usage?
 
-The Operator emits structured logs at `INFO` level for every session, which can be shipped to your existing logging or SIEM stack. See [Monitoring](monitoring.md) for the full field reference and for Prometheus, OpenTelemetry, DataDog, Grafana, and fluentd/Elasticsearch integration.
+The Operator logs an event for every session at `INFO` level, which is the default log level. To get these in a form your logging or SIEM stack can ingest, set `operator.jsonLog` to `true` in the Operator Helm chart values.
+
+**Enable this before you need it.** JSON logging is off by default, and turning it on is not retroactive: sessions that ran before you enabled it leave no ingestible record. If mirrord usage needs to be auditable, set it at install time.
+
+See [Monitoring](monitoring.md) for the full field reference and for Prometheus, OpenTelemetry, DataDog, Grafana, and fluentd/Elasticsearch integration.
 
 Logged events include `Session Start`, `Session End`, `Port Steal`, `Port Mirror`, `Port Release`, and `Copy Target`. Fields relevant to an audit trail include:
 

--- a/docs/managing-mirrord/security.md
+++ b/docs/managing-mirrord/security.md
@@ -40,8 +40,43 @@ You can also visit our [Trust Center](https://trust.metalbear.com) for an overvi
 * The operator requires exclusions from the following gatekeeper policies:
   * `runAsNonRoot` - to access target pod's filesystem
   * `HostPath volume`/`Sharing the host namespace` - to access target pod's file system and networking
-* mirrord doesn't copy remote files or secrets to the local filesystem. The local app only gets access to remote files and secrets in memory, and so they'll only be written to the local filesystem if done by the local app, or if mirrord was explicitly configured to log to files with a log level of debug/trace.
+* mirrord doesn't copy remote files or secrets to the local filesystem. The local app only gets access to remote files and secrets in memory, and so they'll only be written to the local filesystem if done by the local app, or if mirrord was explicitly configured to log to files with a log level of debug/trace. See [below](#does-mirrord-reduce-secret-sprawl-on-developer-machines) for why this often reduces the number of secrets held on developer machines.
+* Operator activity is logged per session, including the Kubernetes user, the target, and the traffic filter in use. See [Auditing mirrord usage](#how-do-i-audit-mirrord-usage).
+* mirrord can run fully air-gapped, with no outbound communication to MetalBear. See [Air-gapped operation](#can-mirrord-run-air-gapped).
 * Missing anything? Feel free to ask us on [Slack](https://metalbear.com/slack) or hi@metalbear.com
+
+## Does mirrord reduce secret sprawl on developer machines?
+
+Usually, yes. A common pattern for local development against cloud dependencies is to copy credentials for services like databases and message queues into a local `.env` file so the application can reach them from a developer's machine. Those credentials then persist on laptops, get shared between engineers, and are rarely rotated.
+
+With mirrord, the local process joins the target pod's network context and reads environment variables and files from the target in memory. The developer's machine never needs a copy of those credentials, and access is bounded by the Kubernetes RBAC the user already has. Removing that class of long-lived local credential is often the strongest security argument for adopting mirrord, rather than a cost of it.
+
+This is a property of how mirrord works, not a guarantee about your environment: an application can still write secrets to disk itself, and mirrord will do so if explicitly configured to log at debug/trace level.
+
+## How do I audit mirrord usage?
+
+The Operator emits structured logs at `INFO` level for every session, which can be shipped to your existing logging or SIEM stack. See [Monitoring](monitoring.md) for the full field reference and for Prometheus, OpenTelemetry, DataDog, Grafana, and fluentd/Elasticsearch integration.
+
+Logged events include `Session Start`, `Session End`, `Port Steal`, `Port Mirror`, `Port Release`, and `Copy Target`. Fields relevant to an audit trail include:
+
+* `client_user` - the Kubernetes user of the client, resolved via Kubernetes RBAC
+* `client_hostname`, `client_name`, `client_id` - identity of the machine and client certificate
+* `target` - the session's target
+* `session_id`, `session_duration` - correlation and length of each session
+* `http_filter` - the client's configured HTTP filter
+
+Because `client_user`, `target`, and `http_filter` are recorded together, you can trace which user was receiving which subset of traffic from a shared target at any point in time, including when several engineers are working against the same service concurrently.
+
+## Can mirrord run air-gapped?
+
+Yes, on the Enterprise plan. Run the [License Server](license-server.md) on-prem to manage seats locally. In this configuration the Operator sends no telemetry or license verification traffic to MetalBear.
+
+## How is the Operator built and distributed?
+
+* The mirrord agent is [open source](https://github.com/metalbear-co/mirrord) and can be audited directly. The Operator is closed source.
+* The Operator is distributed as a versioned container image from `ghcr.io/metalbear-co/operator`, installed via our [public Helm charts](https://github.com/metalbear-co/charts). Each chart release pins a matching `appVersion`, so the chart and the images it deploys move together.
+* Because you control when you bump the chart version, you control when a new Operator or agent image enters your cluster. Chart releases are public and can be reviewed before you upgrade.
+* If we become aware of a vulnerability affecting a released version, we notify affected customers.
 
 ## What data does the mirrord Operator send to MetalBear cloud?
 


### PR DESCRIPTION
## Why

Security teams reviewing the Operator ask three questions this page doesn't answer:

1. Is mirrord usage auditable, and can we trace who was receiving which traffic?
2. How is the Operator built and distributed into our cluster?
3. Can it run without calling home?

Two of the three were already true and documented, just not reachable from the page a security reviewer is pointed at. `audit` currently appears zero times in this repo.

## What changed

- **Auditing section** cross-linking `monitoring.md`, which already documents per-session functional logs. Calls out that `client_user` + `target` + `http_filter` together answer the "who was getting which traffic from a shared target" question.
- **Air-gap section** cross-linking `license-server.md`.
- **Distribution section** stating only publicly verifiable facts: agent is open source, Operator ships as a versioned image from ghcr.io, charts pin a matching `appVersion` so upgrade timing is customer-controlled.
- **Secret sprawl section**, promoting the existing in-memory behaviour from a mid-list bullet into its own section. Removing long-lived credentials from laptops reads as a reason to adopt mirrord, not a footnote.
- Three new bullets in the security-engineer checklist pointing at the above.

## Note for review

I deliberately did **not** add a SLSA / build-provenance claim. It gets stated verbally in security reviews and lands well, but I couldn't find SLSA, provenance, attestation, cosign, or sigstore anywhere in the mirrord or operator CI. If provenance is in fact generated, it's worth documenting explicitly and I'll add it. If not, it probably shouldn't be claimed on calls either.

Please sanity check the vulnerability notification line against what we actually commit to.