### PR TITLE
Document what the Operator sends to the cloud with identity sharing enabled (PRO-231)

### DIFF
--- a/docs/managing-mirrord/operator.md
+++ b/docs/managing-mirrord/operator.md
@@ -44,6 +44,8 @@ curl https://raw.githubusercontent.com/metalbear-co/charts/main/mirrord-operator
 
 The Operator authenticates to the mirrord cloud with a **cloud API key** and uses it to obtain its license over the API. This is the default way to install the Operator. Generate a key in the dashboard under **Settings** at [app.metalbear.com](https://app.metalbear.com) — it's shown only once, so store it then.
 
+When generating the key you also choose whether to enable **identity sharing**. With it on, the Operator's usage metrics include developer usernames and session targets so the usage dashboard can show them by name; with it off, usage metrics stay anonymized. The exact fields are listed under [What data does the Operator send to MetalBear cloud](security.md#what-data-does-the-mirrord-operator-send-to-metalbear-cloud). To force anonymized metrics at the cluster level regardless of the key, set `cloud.anonymizeData: true` in your Helm values.
+
 Provide the key to the chart in one of three ways:
 
 **Kubernetes secret (recommended)** — reference a secret via `cloud.apiKey.keyRef`, so the key never lives in your `values.yaml`:

--- a/docs/managing-mirrord/operator.md
+++ b/docs/managing-mirrord/operator.md
@@ -44,7 +44,7 @@ curl https://raw.githubusercontent.com/metalbear-co/charts/main/mirrord-operator
 
 The Operator authenticates to the mirrord cloud with a **cloud API key** and uses it to obtain its license over the API. This is the default way to install the Operator. Generate a key in the dashboard under **Settings** at [app.metalbear.com](https://app.metalbear.com) — it's shown only once, so store it then.
 
-When generating the key you also choose whether to enable **identity sharing**. With it on, the Operator's usage metrics include developer usernames and session targets so the usage dashboard can show them by name; with it off, usage metrics stay anonymized. The exact fields are listed under [What data does the Operator send to MetalBear cloud](security.md#what-data-does-the-mirrord-operator-send-to-metalbear-cloud). To force anonymized metrics at the cluster level regardless of the key, set `cloud.anonymizeData: true` in your Helm values.
+When generating the key you also choose whether to enable **identity sharing**. With it on, usage metrics include developer usernames and session targets so the usage dashboard can show them by name; with it off, usage metrics stay anonymized. The fields are listed under [What data does the Operator send to MetalBear cloud](security.md#what-data-does-the-mirrord-operator-send-to-metalbear-cloud). Set `cloud.anonymizeData: true` in your Helm values to keep metrics anonymized regardless of the key.
 
 Provide the key to the chart in one of three ways:
 

--- a/docs/managing-mirrord/security.md
+++ b/docs/managing-mirrord/security.md
@@ -28,7 +28,7 @@ You can also visit our [Trust Center](https://trust.metalbear.com) for an overvi
 
 ## I'm a Security Engineer evaluating mirrord for Teams, what do I need to know?
 
-* mirrord for Teams is completely on-prem. The only data sent to our cloud is license verification and usage metrics (see [details below](#what-data-does-the-mirrord-operator-send-to-metalbear-cloud)), which can be customized or disabled upon request. Usage metrics include developer usernames and session targets when identity sharing is on, which is the default for cloud API keys generated at app.metalbear.com; your organization can turn it off to keep them anonymized.
+* mirrord for Teams is completely on-prem. The only data sent to our cloud is license verification and usage metrics (see [details below](#what-data-does-the-mirrord-operator-send-to-metalbear-cloud)), which can be customized or disabled upon request. Usage metrics include developer usernames and session targets when identity sharing is on, which is the default for cloud API keys; your organization can turn it off to keep them anonymized.
 * mirrord does not require root permissions on the user's machine.
 * mirrord for Teams uses Kubernetes RBAC, meaning it doesn't add a new attack vector to your cluster.
 * Communication between the mirrord client and the mirrord Operator takes place over your existing Kubernetes API. If you’ve configured your cluster to encrypt this communication (as is commonly done), then mirrord for Teams’ client-server communication is encrypted as well.

--- a/docs/managing-mirrord/security.md
+++ b/docs/managing-mirrord/security.md
@@ -87,7 +87,7 @@ For our vulnerability disclosure and customer notification process, see the [Tru
 
 ## What data does the mirrord Operator send to MetalBear cloud?
 
-mirrord for Teams is completely on-prem. The Operator communicates with MetalBear servers over an encrypted TLS connection only for license verification and usage metrics. What the usage metrics contain depends on the identity sharing setting of your organization, described below.
+mirrord for Teams is completely on-prem. The Operator communicates with MetalBear servers over an encrypted TLS connection only for license verification and usage metrics. What the usage metrics contain depends on your organization's identity sharing setting.
 
 ### Always sent (anonymized)
 
@@ -112,16 +112,16 @@ Identity sharing is a choice your organization makes when an organization admin 
 2. Local username and hostname of the client machine
 3. Namespace, kind, name, and container of the session's target
 
-This is what lets the usage dashboard at app.metalbear.com show real usernames and service names instead of hashes. It is the only data beyond the anonymized fields above that the Operator sends. Anonymized metrics go to `analytics.metalbear.com`; events that carry identity go to `app.metalbear.com`.
+These are what the usage dashboard at app.metalbear.com uses to show usernames and service names instead of hashes. Anonymized metrics go to `analytics.metalbear.com`; events that carry identity go to `app.metalbear.com`.
 
-Identity is never sent when any of the following apply:
+Identity is not sent when:
 
 * The cloud API key was generated with identity sharing unticked.
-* `cloud.anonymizeData` is `true` in the Operator's Helm values. This overrides the key's setting, so you can enforce anonymized metrics at the cluster level regardless of who generated the key.
+* `cloud.anonymizeData` is `true` in the Operator's Helm values. This overrides the key's setting.
 * The Operator authenticates with a legacy license key instead of a cloud API key.
-* The Operator authenticates against a self-hosted [License Server](license-server.md). In that configuration nothing is sent to MetalBear at all.
+* The Operator authenticates against a self-hosted [License Server](license-server.md). Nothing is sent to MetalBear in that configuration.
 
-To change the setting for an existing installation, generate a new cloud API key with the choice you want and roll the Operator over to it.
+To change the setting on an existing installation, generate a new cloud API key and roll the Operator over to it.
 
 In the Enterprise offering, this communication can be disabled entirely.
 

--- a/docs/managing-mirrord/security.md
+++ b/docs/managing-mirrord/security.md
@@ -1,7 +1,7 @@
 ---
 title: Security
 date: 2022-07-10T08:48:57.000Z
-lastmod: 2024-03-01T00:00:00.000Z
+lastmod: 2026-08-27T00:00:00.000Z
 draft: false
 images: []
 linktitle: Security
@@ -28,7 +28,7 @@ You can also visit our [Trust Center](https://trust.metalbear.com) for an overvi
 
 ## I'm a Security Engineer evaluating mirrord for Teams, what do I need to know?
 
-* mirrord for Teams is completely on-prem. The only data sent to our cloud is analytics and license verification (see [details below](#what-data-does-the-mirrord-operator-send-to-metalbear-cloud)) which can be customized or disabled upon request. The analytics don't contain PII or any sensitive information.
+* mirrord for Teams is completely on-prem. The only data sent to our cloud is license verification and usage metrics (see [details below](#what-data-does-the-mirrord-operator-send-to-metalbear-cloud)), which can be customized or disabled upon request. Usage metrics are anonymized by default; whether developer usernames and session targets are included is a setting your organization controls.
 * mirrord does not require root permissions on the user's machine.
 * mirrord for Teams uses Kubernetes RBAC, meaning it doesn't add a new attack vector to your cluster.
 * Communication between the mirrord client and the mirrord Operator takes place over your existing Kubernetes API. If you’ve configured your cluster to encrypt this communication (as is commonly done), then mirrord for Teams’ client-server communication is encrypted as well.
@@ -87,7 +87,9 @@ For our vulnerability disclosure and customer notification process, see the [Tru
 
 ## What data does the mirrord Operator send to MetalBear cloud?
 
-mirrord for Teams is completely on-prem. The Operator communicates with MetalBear servers over an encrypted TLS connection only for license verification and anonymous usage metrics. The fields shared are:
+mirrord for Teams is completely on-prem. The Operator communicates with MetalBear servers over an encrypted TLS connection only for license verification and usage metrics. What the usage metrics contain depends on the identity sharing setting of your organization, described below.
+
+### Always sent (anonymized)
 
 1. User ID (randomly generated hash, stored on user machine)
 2. Duration of session
@@ -99,6 +101,27 @@ mirrord for Teams is completely on-prem. The Operator communicates with MetalBea
 8. cluster_id (the UID of the cluster's `default` namespace, used as a stable, anonymous per-cluster identifier)
 9. cluster_name (optional; only sent if you set the `operator.clusterName` Helm value to give the cluster a recognizable label)
 10. kubernetes_version (the version of the Kubernetes cluster the Operator is running in)
+
+None of these fields identify an individual developer or a workload in your cluster.
+
+### Sent only with identity sharing enabled
+
+Identity sharing is a choice your organization makes when an organization admin generates a [cloud API key](operator.md#cloud-api-key) at [app.metalbear.com](https://app.metalbear.com). It is ticked by default for new keys; untick it to keep usage metrics fully anonymized. With it enabled, each session event also carries:
+
+1. Kubernetes username of the client, as resolved by your cluster's RBAC
+2. Local username and hostname of the client machine
+3. Namespace, kind, name, and container of the session's target
+
+This is what lets the usage dashboard at app.metalbear.com show real usernames and service names instead of hashes. It is the only data beyond the anonymized fields above that the Operator sends. Anonymized metrics go to `analytics.metalbear.com`; events that carry identity go to `app.metalbear.com`.
+
+Identity is never sent when any of the following apply:
+
+* The cloud API key was generated with identity sharing unticked.
+* `cloud.anonymizeData` is `true` in the Operator's Helm values. This overrides the key's setting, so you can enforce anonymized metrics at the cluster level regardless of who generated the key.
+* The Operator authenticates with a legacy license key instead of a cloud API key.
+* The Operator authenticates against a self-hosted [License Server](license-server.md). In that configuration nothing is sent to MetalBear at all.
+
+To change the setting for an existing installation, generate a new cloud API key with the choice you want and roll the Operator over to it.
 
 In the Enterprise offering, this communication can be disabled entirely.
 

--- a/docs/managing-mirrord/security.md
+++ b/docs/managing-mirrord/security.md
@@ -28,7 +28,7 @@ You can also visit our [Trust Center](https://trust.metalbear.com) for an overvi
 
 ## I'm a Security Engineer evaluating mirrord for Teams, what do I need to know?
 
-* mirrord for Teams is completely on-prem. The only data sent to our cloud is license verification and usage metrics (see [details below](#what-data-does-the-mirrord-operator-send-to-metalbear-cloud)), which can be customized or disabled upon request. Usage metrics are anonymized by default; whether developer usernames and session targets are included is a setting your organization controls.
+* mirrord for Teams is completely on-prem. The only data sent to our cloud is license verification and usage metrics (see [details below](#what-data-does-the-mirrord-operator-send-to-metalbear-cloud)), which can be customized or disabled upon request. Usage metrics include developer usernames and session targets when identity sharing is on, which is the default for cloud API keys generated at app.metalbear.com; your organization can turn it off to keep them anonymized.
 * mirrord does not require root permissions on the user's machine.
 * mirrord for Teams uses Kubernetes RBAC, meaning it doesn't add a new attack vector to your cluster.
 * Communication between the mirrord client and the mirrord Operator takes place over your existing Kubernetes API. If you’ve configured your cluster to encrypt this communication (as is commonly done), then mirrord for Teams’ client-server communication is encrypted as well.
@@ -116,7 +116,7 @@ These are what the usage dashboard at app.metalbear.com uses to show usernames a
 
 Identity is not sent when:
 
-* The cloud API key was generated with identity sharing unticked.
+* The cloud API key was generated with identity sharing unticked, or the organization's key predates the setting and it was never turned on.
 * `cloud.anonymizeData` is `true` in the Operator's Helm values. This overrides the key's setting.
 * The Operator authenticates with a legacy license key instead of a cloud API key.
 * The Operator authenticates against a self-hosted [License Server](license-server.md). A cloud API key is ignored in that configuration and usage metrics stay anonymized.

--- a/docs/managing-mirrord/security.md
+++ b/docs/managing-mirrord/security.md
@@ -106,10 +106,10 @@ None of these fields identify an individual developer or a workload in your clus
 
 ### Sent only with identity sharing enabled
 
-Identity sharing is a choice your organization makes when an organization admin generates a [cloud API key](operator.md#cloud-api-key) at [app.metalbear.com](https://app.metalbear.com). It is ticked by default for new keys; untick it to keep usage metrics fully anonymized. With it enabled, each session event also carries:
+Identity sharing is an organization-level setting. An organization admin chooses it when generating a [cloud API key](operator.md#cloud-api-key) at [app.metalbear.com](https://app.metalbear.com), where it is ticked by default, and can change it later for the current key on the same page. With it enabled, the Operator's events also carry, where applicable:
 
-1. Kubernetes username of the client, as resolved by your cluster's RBAC
-2. Local username and hostname of the client machine
+1. Kubernetes username of the client, as authenticated by your Kubernetes API server
+2. Display name of the local account and hostname of the client machine
 3. Namespace, kind, name, and container of the session's target
 
 These are what the usage dashboard at app.metalbear.com uses to show usernames and service names instead of hashes. Anonymized metrics go to `analytics.metalbear.com`; events that carry identity go to `app.metalbear.com`.
@@ -119,9 +119,9 @@ Identity is not sent when:
 * The cloud API key was generated with identity sharing unticked.
 * `cloud.anonymizeData` is `true` in the Operator's Helm values. This overrides the key's setting.
 * The Operator authenticates with a legacy license key instead of a cloud API key.
-* The Operator authenticates against a self-hosted [License Server](license-server.md). Nothing is sent to MetalBear in that configuration.
+* The Operator authenticates against a self-hosted [License Server](license-server.md). A cloud API key is ignored in that configuration and usage metrics stay anonymized.
 
-To change the setting on an existing installation, generate a new cloud API key and roll the Operator over to it.
+Changing the setting takes effect at the Operator's next cloud token refresh, without regenerating the key or restarting the Operator.
 
 In the Enterprise offering, this communication can be disabled entirely.
 


### PR DESCRIPTION
## Summary

The security page listed only the anonymized telemetry fields, so it no longer described what the Operator sends once a cloud API key with identity sharing is in use. This splits the "What data does the mirrord Operator send" section into the anonymized fields (unchanged) and the identity fields that are added only with identity sharing enabled, and spells out every case in which identity is not sent (key generated with sharing off, `cloud.anonymizeData: true`, legacy license key, self-hosted license server).

The cloud API key section on the Operator page gets a short paragraph on the identity sharing choice at key generation, linking to the security section for the field list and naming `cloud.anonymizeData` as the cluster-level override.

Also softens the "analytics don't contain PII" bullet at the top of the security page, since that is only true by default now.

Resolves PRO-231.

## Test plan

- Field list taken from `EventIdentity` in `crates/operator-telemetry/src/types.rs` and the consent gating in `event_sender.rs` (identity is attached only when the cloud token carries consent and `anonymize_data` is false); confirmed by reading the code, not by running it.
- Verified the three link targets exist on main (`security.md` section heading unchanged so the existing anchor keeps working, `operator.md#cloud-api-key`, `license-server.md`).
- No build or lint in this repo; rendered output not checked.