### PR TITLE
Add Agent-Started Trials page (PRO-226)

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -25,6 +25,7 @@
 * [Using mirrord with AI](using-mirrord-with-ai/README.md)
   * [Agent Skills for mirrord](using-mirrord-with-ai/ai-skills-plugin.md)
   * [Configure AI Agents to Use mirrord](using-mirrord-with-ai/the-meta-prompt.md)
+  * [Agent-Started Trials](using-mirrord-with-ai/agent-started-trials.md)
 
 ## Using mirrord
 

--- a/docs/managing-mirrord/licensing.md
+++ b/docs/managing-mirrord/licensing.md
@@ -106,4 +106,6 @@ Enterprise licenses additionally support persistent sessions, which survive oper
 
 Register at [app.metalbear.com](https://app.metalbear.com) to get a Teams license key. For Enterprise licensing, [contact us](mailto:hi@metalbear.com).
 
+An AI coding agent working on an unlicensed cluster can also start a trial itself and hand you a link to claim the organization. See [Agent-Started Trials](../using-mirrord-with-ai/agent-started-trials.md).
+
 Once you have a key, see the [Operator installation guide](operator.md) for setup instructions.

--- a/docs/using-mirrord-with-ai/README.md
+++ b/docs/using-mirrord-with-ai/README.md
@@ -15,3 +15,4 @@ Here are some ways you can connect mirrord to your AI coding workflow:
 - **[Agent skills for mirrord](./ai-skills-plugin.md)** - Install skills that give your AI assistant built-in mirrord expertise.
 - **[Configure AI Agents to Use mirrord](./the-meta-prompt.md)** - A prompt generator that creates project-specific `AGENTS.md` files and configurations automatically, saving hours of manual setup across multiple services.
 - **[metalbear.com/agents.md](https://metalbear.com/agents.md)** - A short operational reference written for agents rather than people: install commands, finding targets, running code through mirrord, configuration, and etiquette on a shared cluster. Point an agent at the URL directly when you want it to pick mirrord up without any repository setup.
+- **[Agent-Started Trials](./agent-started-trials.md)** - On a cluster with no mirrord for Teams license, an agent can start a trial itself and hand you a link to claim the organization it created.

--- a/docs/using-mirrord-with-ai/agent-started-trials.md
+++ b/docs/using-mirrord-with-ai/agent-started-trials.md
@@ -22,14 +22,14 @@ curl -fsS -X POST https://app.metalbear.com/api/v1/agent/signup \
 
 `developer_email` and `cluster_hint` are optional and unverified. They exist so you can recognize the organization as yours on the claim page.
 
-The response is a **provisional organization** carrying an Enterprise trial license:
+The response is a **provisional organization** carrying an Enterprise trial license, good for seven days from the signup:
 
 ```json
 {
   "organization_id": "...",
   "api_key": "...",
   "license_type": "enterprise-trial",
-  "trial_ends_at": "2026-10-08T12:00:00+00:00",
+  "trial_ends_at": "2026-09-17T12:00:00+00:00",
   "claim_code": "mbclaim_...",
   "claim_url": "https://app.metalbear.com/claim?code=mbclaim_...",
   "instructions_url": "https://metalbear.com/agents.md"
@@ -50,7 +50,7 @@ Open the claim URL and sign in. What happens next depends on the account you use
 
 Claiming also deletes the provisional organization, so the cluster keeps working against your real one without reinstalling anything.
 
-An existing organization that already holds an active cloud API key will reject the claim rather than replace the key it has. Revoke or rotate the existing key first, under **API Keys**.
+An existing organization that already holds an active Operator cloud API key will reject the claim rather than replace the key it has. Revoke or rotate the existing key first, under **API Keys**. Read-only keys are a different scope and don't collide, so they can stay.
 
 ## Until it is claimed
 

--- a/docs/using-mirrord-with-ai/agent-started-trials.md
+++ b/docs/using-mirrord-with-ai/agent-started-trials.md
@@ -40,15 +40,15 @@ The agent installs the Operator with that key as `cloud.apiKey.key` (see [Cloud 
 
 ## Claiming the organization
 
-Open the claim URL and sign in. What happens next depends on the account you use.
+Open the claim URL. You can sign in with an existing account or create one on the spot; the link survives either, including the verification mail that account creation sends you. What happens next depends on the account you use.
 
 | You sign in as | Result |
 | --- | --- |
-| A new account with no organization | A new organization is created for you, keeping the trial's expiry date |
+| A new account with no organization | A new organization is created for you, keeping the trial's expiry date and everything the agent already did |
 | An admin of an existing organization | The agent's cloud API key moves into your existing organization |
 | A member of an existing organization who is not an admin | Rejected. Ask an admin to open the link |
 
-Claiming also deletes the provisional organization, so the cluster keeps working against your real one without reinstalling anything.
+Claiming also deletes the provisional organization, so the cluster keeps working against your real one without reinstalling anything. A new organization inherits the agent's history along with the license, so the getting-started checklist already counts the Operator as installed and your usage shows the sessions the agent ran before you claimed. An organization that already existed keeps its own license, and so its own history.
 
 An existing organization that already holds an active Operator cloud API key will reject the claim rather than replace the key it has. Revoke or rotate the existing key first, under **API Keys**. Read-only keys are a different scope and don't collide, so they can stay.
 

--- a/docs/using-mirrord-with-ai/agent-started-trials.md
+++ b/docs/using-mirrord-with-ai/agent-started-trials.md
@@ -1,0 +1,66 @@
+---
+title: Agent-Started Trials
+description: How an AI coding agent starts a mirrord for Teams trial, and how to claim the organization it creates
+draft: false
+toc: true
+tags: ["team", "enterprise"]
+---
+
+Some things an agent needs on a shared cluster only work with mirrord for Teams: branching a database so its writes don't reach everyone else's data, splitting a queue so it doesn't eat messages other people need, or stealing traffic from a target another session already holds.
+
+On a cluster with no license, an agent that follows [metalbear.com/agents.md](https://metalbear.com/agents.md) can start a trial itself rather than stopping and waiting for you to sign up. It ends up with a working cluster and you end up with a link to claim.
+
+## What the agent does
+
+It posts to the signup endpoint. No authentication, no credit card:
+
+```bash
+curl -fsS -X POST https://app.metalbear.com/api/v1/agent/signup \
+  -H 'content-type: application/json' \
+  -d '{"agent": "claude-code", "developer_email": "you@example.com", "cluster_hint": "staging"}'
+```
+
+`developer_email` and `cluster_hint` are optional and unverified. They exist so you can recognize the organization as yours on the claim page.
+
+The response is a **provisional organization** carrying an Enterprise trial license:
+
+```json
+{
+  "organization_id": "...",
+  "api_key": "...",
+  "license_type": "enterprise-trial",
+  "trial_ends_at": "2026-10-08T12:00:00+00:00",
+  "claim_code": "mbclaim_...",
+  "claim_url": "https://app.metalbear.com/claim?code=mbclaim_...",
+  "instructions_url": "https://metalbear.com/agents.md"
+}
+```
+
+The agent installs the Operator with that key as `cloud.apiKey.key` (see [Cloud API key](../managing-mirrord/operator.md#cloud-api-key)), then gives you the `claim_url`.
+
+## Claiming the organization
+
+Open the claim URL and sign in. What happens next depends on the account you use.
+
+| You sign in as | Result |
+| --- | --- |
+| A new account with no organization | A new organization is created for you, keeping the trial's expiry date |
+| An admin of an existing organization | The agent's cloud API key moves into your existing organization |
+| A member of an existing organization who is not an admin | Rejected. Ask an admin to open the link |
+
+Claiming also deletes the provisional organization, so the cluster keeps working against your real one without reinstalling anything.
+
+An existing organization that already holds an active cloud API key will reject the claim rather than replace the key it has. Revoke or rotate the existing key first, under **API Keys**.
+
+## Until it is claimed
+
+A provisional organization is not a stuck state for the agent. The trial license works, so the cluster is usable straight away. What is missing is a person:
+
+- **Nobody can administer it.** Billing, seats, and members all need a human owner, and the first person to claim it becomes that owner.
+- **It expires with the trial.** An unclaimed organization reaches `trial_ends_at` with nobody able to renew or convert it.
+
+Claim codes are single-use. Once one has been claimed, opening the same link from a different organization fails rather than silently joining it. Reopening it as the same admin who claimed it is harmless.
+
+## If you already have an organization
+
+You don't need any of this. Generate a cloud API key under **API Keys** and give it to the agent, or install the Operator yourself following the [dashboard setup guide](../managing-mirrord/dashboard/cloud.md). Signing up again creates a second organization you then have to clean up.


### PR DESCRIPTION
## Summary

An AI coding agent blocked on an unlicensed shared cluster can now provision a trial itself: it posts to the agent signup endpoint, gets a provisional organization with an Enterprise trial license and a cloud API key, installs the Operator with that key, and hands the user a claim URL. Nothing in the docs said what the user does with that link.

New page under **Using mirrord with AI**:

- What the agent sends and what comes back.
- What claiming does for each kind of account: a new account gets an organization carrying the trial's expiry, an admin of an existing organization gets the agent's API key moved into it, a non-admin member is rejected. Also the case where the existing organization already holds an active cloud API key.
- What stays blocked while an organization is unclaimed (billing, seats, members) and that it expires with the trial.
- A pointer back to the normal path for anyone who already has an organization.

Cross-linked from `using-mirrord-with-ai/README.md` and from **Getting a License** in `managing-mirrord/licensing.md`.

Draft until operator#2328 is in production and the endpoint is enabled there, since merging publishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)