### PR TITLE
Point the install and preview pages at the agent trial path

### DIFF
--- a/docs/managing-mirrord/operator.md
+++ b/docs/managing-mirrord/operator.md
@@ -26,6 +26,10 @@ The Operator solves this by acting as a centralized control plane:
 
 You'll need a mirrord for Teams license. [Register here](https://app.metalbear.com) to get started.
 
+{% hint style="info" %}
+**AI coding agents:** you don't need a person to do this. Post to `https://app.metalbear.com/api/v1/agent/signup` (no authentication, no credit card) to provision a seven-day Enterprise trial, install with the cloud API key it returns, and hand your user the `claim_url` from the response. See [Agent-Started Trials](../using-mirrord-with-ai/agent-started-trials.md) and [metalbear.com/agents.md](https://metalbear.com/agents.md).
+{% endhint %}
+
 ### Helm
 
 Add the MetalBear Helm repository:
@@ -43,6 +47,8 @@ curl https://raw.githubusercontent.com/metalbear-co/charts/main/mirrord-operator
 ### Cloud API key
 
 The Operator authenticates to the mirrord cloud with a **cloud API key** and uses it to obtain its license over the API. This is the default way to install the Operator. Generate a key in the dashboard under **Settings** at [app.metalbear.com](https://app.metalbear.com) — it's shown only once, so store it then.
+
+If you have no organization yet and an AI agent is doing the install, [Agent-Started Trials](../using-mirrord-with-ai/agent-started-trials.md) mints the same kind of key without a dashboard visit.
 
 When generating the key you also choose whether to enable **identity sharing**. With it on, usage metrics include developer usernames and session targets so the usage dashboard can show them by name; with it off, usage metrics stay anonymized. The fields are listed under [What data does the Operator send to MetalBear cloud](../managing-mirrord/security.md#what-data-does-the-mirrord-operator-send-to-metalbear-cloud). Set `cloud.anonymizeData: true` in your Helm values to keep metrics anonymized regardless of the key.
 

--- a/docs/use-cases/preview-environments.md
+++ b/docs/use-cases/preview-environments.md
@@ -27,6 +27,7 @@ This feature is available to users on the Enterprise pricing plan.
 
 #### Prerequisites
 
+* **An Enterprise license.** A [free trial](https://app.metalbear.com/account/sign-up) is minted as an Enterprise one, so preview environments work for its duration. An AI agent on a cluster with no license can provision that trial itself, without waiting for a person: see [Agent-Started Trials](../using-mirrord-with-ai/agent-started-trials.md).
 * **Operator 3.142.0 or later** — the feature was introduced in this version.
 * **CLI 3.189.0 or later** — the `mirrord preview` subcommand was introduced in this version.
 *   **Helm flag** — `operator.previewEnv` must be set to `true` in your Helm values (defaults to `false`):

--- a/docs/using-mirrord-with-ai/agent-started-trials.md
+++ b/docs/using-mirrord-with-ai/agent-started-trials.md
@@ -38,6 +38,8 @@ The response is a **provisional organization** carrying an Enterprise trial lice
 
 The agent installs the Operator with that key as `cloud.apiKey.key` (see [Cloud API key](../managing-mirrord/operator.md#cloud-api-key)), then gives you the `claim_url`.
 
+Because the trial is an Enterprise license, it also covers the features a Team license doesn't, including [Preview Environments](../use-cases/preview-environments.md). Those need `operator.previewEnv=true` in the Helm values, which defaults to `false` and can't be turned on after the fact without a `helm upgrade`, so it's worth setting during the agent's install.
+
 ## Claiming the organization
 
 Open the claim URL. You can sign in with an existing account or create one on the spot; the link survives either, including the verification mail that account creation sends you. What happens next depends on the account you use.


### PR DESCRIPTION
## Summary

Two pages describe the agent trial path as if it did not exist, and they are the two pages you land on when you need it.

**`managing-mirrord/operator.md`** opens Installation with "You'll need a mirrord for Teams license. Register here" and later says to generate a key "in the dashboard under Settings". That is the only route it describes, so a reader who arrives there with no organization is sent to a browser regardless of whether a person is driving. It now carries a hint block with the signup endpoint and links to Agent-Started Trials, plus a line next to the Settings instruction for the case where there is no organization yet.

**`use-cases/preview-environments.md`** states the feature needs an Enterprise plan and then lists three prerequisites: an Operator version, a CLI version, and a Helm flag. How to obtain a license is not among them, so the page dead-ends for anyone who does not already have one. An Enterprise license is now prerequisite number one, noting that a free trial is minted as an Enterprise one and that an agent can provision that trial itself.

**`using-mirrord-with-ai/agent-started-trials.md`** gains the other half of that link: the trial covers preview environments, and `operator.previewEnv` defaults to `false` and has to be set during the install rather than afterwards.

Text only, no structural or navigation changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)